### PR TITLE
feat: add initial user collection & add notes

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -15,6 +15,12 @@
 | setprefix       | Text         | Set the bot prefix.                               |
 | setstaffrole    | Role         | Set the bot staff role.                           |
 
+## Notes
+| Commands   | Arguments            | Description                                  |
+| ---------- | -------------------- | -------------------------------------------- |
+| deleteNote | Member, Integer      | Use this to add a delete a note from a user. |
+| note       | Member, Note Content | Use this to add a note to a user.            |
+
 ## Utility
 | Commands | Arguments | Description          |
 | -------- | --------- | -------------------- |

--- a/src/main/kotlin/me/ddivad/judgebot/commands/NoteCommands.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/commands/NoteCommands.kt
@@ -1,0 +1,37 @@
+package me.ddivad.judgebot.commands
+
+import me.ddivad.judgebot.dataclasses.Configuration
+import me.ddivad.judgebot.services.DatabaseService
+import me.ddivad.judgebot.services.PermissionLevel
+import me.ddivad.judgebot.services.requiredPermissionLevel
+import me.jakejmattson.discordkt.api.arguments.EveryArg
+import me.jakejmattson.discordkt.api.arguments.IntegerArg
+import me.jakejmattson.discordkt.api.arguments.MemberArg
+import me.jakejmattson.discordkt.api.dsl.commands
+
+fun noteCommands(databaseService: DatabaseService, configuration: Configuration) = commands("Notes") {
+    command("note") {
+        description = "Use this to add a note to a user."
+        requiresGuild = true
+        requiredPermissionLevel = PermissionLevel.Staff
+        execute(MemberArg, EveryArg("Note Content")) {
+            val (target, note) = args
+            val user = databaseService.users.getOrCreateUser(target, guild!!.id.value)
+            databaseService.users.addNote(guild!!, user, note, author.id.value)
+            respond("Note added.")
+        }
+    }
+
+    command("deleteNote") {
+        description = "Use this to add a delete a note from a user."
+        requiresGuild = true
+        requiredPermissionLevel = PermissionLevel.Staff
+        execute(MemberArg, IntegerArg) {
+            val (target, noteId) = args
+            val user = databaseService.users.getOrCreateUser(target, guild!!.id.value)
+            if (user.getGuildInfo(guild!!.id.value)!!.notes.isEmpty()) return@execute respond("User has no notes.")
+            databaseService.users.deleteNote(guild!!, user, noteId)
+            respond("Note deleted.")
+        }
+    }
+}

--- a/src/main/kotlin/me/ddivad/judgebot/dataclasses/Configuration.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/dataclasses/Configuration.kt
@@ -8,7 +8,7 @@ data class Configuration(
         val ownerId: String = "insert-owner-id",
         var prefix: String = "judge!",
         val guildConfigurations: MutableMap<Long, GuildConfiguration> = mutableMapOf(),
-        val dbConfiguration: DatabaseConfiguration = DatabaseConfiguration(),
+        val dbConfiguration: DatabaseConfiguration = DatabaseConfiguration()
 ) : Data("config/config.json") {
     operator fun get(id: Long) = guildConfigurations[id]
     fun hasGuildConfig(guildId: Long) = guildConfigurations.containsKey(guildId)
@@ -38,7 +38,7 @@ data class GuildConfiguration(
         var prefix: String = "j!",
         var staffRole: String = "",
         var adminRole: String = "",
-        var loggingConfiguration: LoggingConfiguration = LoggingConfiguration(),
+        var loggingConfiguration: LoggingConfiguration = LoggingConfiguration()
 )
 
 data class LoggingConfiguration(

--- a/src/main/kotlin/me/ddivad/judgebot/dataclasses/GuildMember.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/dataclasses/GuildMember.kt
@@ -1,0 +1,39 @@
+package me.ddivad.judgebot.dataclasses
+
+import com.gitlab.kordlib.core.entity.Guild
+import org.joda.time.DateTime
+
+data class GuildDetails(
+        val guildId: String,
+        val notes: MutableList<Note> = mutableListOf<Note>(),
+        var historyCount: Int = 0,
+        var points: Int = 0,
+        var lastInfraction: Long = 0
+)
+
+data class GuildMember(
+        val userId: String,
+        val guilds: MutableList<GuildDetails> = mutableListOf<GuildDetails>()
+) {
+    fun addNote(note: String, moderator: String, guild: Guild) = with(this.getGuildInfo(guild.id.value)) {
+        val nextId: Int = if (this!!.notes.isEmpty()) 1 else this.notes.maxBy { it.id }!!.id + 1
+        this.notes.add(Note(note, moderator, DateTime.now().millis, nextId))
+    }
+
+    fun deleteNote(noteId: Int, guild: Guild) = with(this.getGuildInfo(guild.id.value)) {
+        this?.notes?.removeIf { it.id == noteId }
+    }
+
+    fun incrementHistoryCount(guildId: String) {
+        this.getGuildInfo(guildId)!!.historyCount += 1
+    }
+
+    fun ensureGuildDetailsPresent(guildId: String) {
+        if (this.guilds.any { it.guildId == guildId }) return
+        this.guilds.add(GuildDetails(guildId))
+    }
+
+    fun getGuildInfo(guildId: String): GuildDetails? {
+        return this.guilds.firstOrNull { it.guildId == guildId }
+    }
+}

--- a/src/main/kotlin/me/ddivad/judgebot/dataclasses/Note.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/dataclasses/Note.kt
@@ -1,0 +1,6 @@
+package me.ddivad.judgebot.dataclasses
+
+data class Note(val note: String,
+                val moderator: String,
+                val dateTime: Long,
+                val id: Int)

--- a/src/main/kotlin/me/ddivad/judgebot/services/DatabaseService.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/services/DatabaseService.kt
@@ -1,0 +1,10 @@
+package me.ddivad.judgebot.services
+
+import me.ddivad.judgebot.dataclasses.Configuration
+import me.ddivad.judgebot.services.database.UserOperations
+import me.jakejmattson.discordkt.api.annotations.Service
+
+@Service
+open class DatabaseService(val config: Configuration,
+                           val users: UserOperations) {
+}

--- a/src/main/kotlin/me/ddivad/judgebot/services/database/ConnectionService.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/services/database/ConnectionService.kt
@@ -1,0 +1,16 @@
+package me.ddivad.judgebot.services.database
+
+import com.mongodb.reactivestreams.client.MongoClient
+import com.mongodb.reactivestreams.client.MongoDatabase
+import me.ddivad.judgebot.dataclasses.Configuration
+import me.jakejmattson.discordkt.api.annotations.Service
+import org.litote.kmongo.coroutine.CoroutineClient
+import org.litote.kmongo.coroutine.CoroutineDatabase
+import org.litote.kmongo.coroutine.coroutine
+import org.litote.kmongo.reactivestreams.KMongo
+
+@Service
+class ConnectionService(val config: Configuration) {
+    private val client: CoroutineClient = KMongo.createClient(config.dbConfiguration.address).coroutine
+    val db: CoroutineDatabase = client.getDatabase(config.dbConfiguration.databaseName)
+}

--- a/src/main/kotlin/me/ddivad/judgebot/services/database/UserOperations.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/services/database/UserOperations.kt
@@ -1,0 +1,47 @@
+package me.ddivad.judgebot.services.database
+
+import com.gitlab.kordlib.core.entity.Guild
+import com.gitlab.kordlib.core.entity.Member
+import kotlinx.coroutines.runBlocking
+import me.ddivad.judgebot.dataclasses.GuildDetails
+import me.ddivad.judgebot.dataclasses.GuildMember
+import me.jakejmattson.discordkt.api.annotations.Service
+import org.litote.kmongo.eq
+
+@Service
+class UserOperations(private val connection: ConnectionService) {
+    private val userCollection = connection.db.getCollection<GuildMember>("Users")
+
+    suspend fun getOrCreateUser(target: Member, guildId: String): GuildMember {
+            val userRecord = userCollection.findOne(GuildMember::userId eq target.id.value)
+            return if(userRecord != null) {
+                userRecord.ensureGuildDetailsPresent(guildId)
+                userRecord
+            } else {
+                val guildMember = GuildMember(target.id.value)
+                guildMember.guilds.add(GuildDetails(guildId))
+                userCollection.insertOne(guildMember)
+                guildMember
+            }
+    }
+
+    private suspend fun updateUser(user: GuildMember): GuildMember {
+        userCollection.updateOne(GuildMember::userId eq user.userId, user)
+        return user
+    }
+
+    suspend fun addNote(guild: Guild, user: GuildMember, note: String, moderator: String): GuildMember {
+        user.addNote(note, moderator, guild)
+        return this.updateUser(user)
+    }
+
+    suspend fun deleteNote(guild: Guild, user: GuildMember, noteId: Int): GuildMember {
+        user.deleteNote(noteId, guild)
+        return this.updateUser(user)
+    }
+
+    suspend fun incrementUserHistory(user: GuildMember, guildId: String): GuildMember {
+        user.incrementHistoryCount(guildId)
+        return this.updateUser(user)
+    }
+}


### PR DESCRIPTION
# feat: add initial user collection & add notes

Add initial DB setup, and notes functionality.

Added:
- Database Service, User Operations and DB connection information.
- Note and GuildMember dataclasses.
- Commands to add / remove notes.