### PR TITLE
feat: add rules implementation

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -21,6 +21,16 @@
 | deleteNote | Member, Integer      | Use this to add a delete a note from a user. |
 | note       | Member, Note Content | Use this to add a note to a user.            |
 
+## Rules
+| Commands     | Arguments | Description                   |
+| ------------ | --------- | ----------------------------- |
+| addRule      |           | Add a rule to this guild.     |
+| archiveRule  |           | Archive a rule in this guild. |
+| editRule     |           | Edit a rule in this guild.    |
+| listRules    |           | List the rules of this guild. |
+| rule         | Integer   | List a rule from this guild.  |
+| ruleHeadings |           | List the rules of this guild. |
+
 ## User
 | Commands   | Arguments | Description                            |
 | ---------- | --------- | -------------------------------------- |

--- a/src/main/kotlin/me/ddivad/judgebot/commands/GuildConfigCommands.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/commands/GuildConfigCommands.kt
@@ -2,6 +2,7 @@ package me.ddivad.judgebot.commands
 
 import me.ddivad.judgebot.conversations.ConfigurationConversation
 import me.ddivad.judgebot.dataclasses.Configuration
+import me.ddivad.judgebot.services.DatabaseService
 import me.ddivad.judgebot.services.PermissionLevel
 import me.ddivad.judgebot.services.requiredPermissionLevel
 import me.jakejmattson.discordkt.api.arguments.ChannelArg
@@ -10,7 +11,9 @@ import me.jakejmattson.discordkt.api.arguments.RoleArg
 import me.jakejmattson.discordkt.api.dsl.commands
 import me.jakejmattson.discordkt.api.services.ConversationService
 
-fun guildConfigCommands(configuration: Configuration, conversationService: ConversationService) = commands("Configuration") {
+fun guildConfigCommands(configuration: Configuration,
+                        conversationService: ConversationService,
+                        databaseService: DatabaseService) = commands("Configuration") {
     command("configure") {
         description = "Configure a guild to use Judgebot."
         requiredPermissionLevel = PermissionLevel.Administrator
@@ -19,6 +22,7 @@ fun guildConfigCommands(configuration: Configuration, conversationService: Conve
                 return@execute respond("Guild configuration exists. To modify it use the commands to set values.")
 
             conversationService.startPublicConversation<ConfigurationConversation>(author, channel.asChannel(), guild!!)
+            databaseService.guilds.setupGuild(guild!!)
             respond("Guild setup")
         }
     }

--- a/src/main/kotlin/me/ddivad/judgebot/commands/RuleCommands.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/commands/RuleCommands.kt
@@ -1,0 +1,75 @@
+package me.ddivad.judgebot.commands
+
+import me.ddivad.judgebot.conversations.rules.AddRuleConversation
+import me.ddivad.judgebot.conversations.rules.ArchiveRuleConversation
+import me.ddivad.judgebot.conversations.rules.EditRuleConversation
+import me.ddivad.judgebot.dataclasses.Configuration
+import me.ddivad.judgebot.embeds.createRuleEmbed
+import me.ddivad.judgebot.embeds.createRulesEmbed
+import me.ddivad.judgebot.embeds.createRulesEmbedDetailed
+import me.ddivad.judgebot.services.DatabaseService
+import me.ddivad.judgebot.services.PermissionLevel
+import me.ddivad.judgebot.services.requiredPermissionLevel
+import me.jakejmattson.discordkt.api.arguments.IntegerArg
+import me.jakejmattson.discordkt.api.dsl.commands
+import me.jakejmattson.discordkt.api.services.ConversationService
+
+fun ruleCommands(configuration: Configuration,
+                        conversationService: ConversationService,
+                        databaseService: DatabaseService) = commands("Rules") {
+
+    command("addRule") {
+        description = "Add a rule to this guild."
+        requiredPermissionLevel = PermissionLevel.Administrator
+        execute {
+            conversationService.startPublicConversation<AddRuleConversation>(author, channel.asChannel(), guild!!)
+        }
+    }
+
+    command("editRule") {
+        description = "Edit a rule in this guild."
+        requiredPermissionLevel = PermissionLevel.Administrator
+        execute {
+            conversationService.startPublicConversation<EditRuleConversation>(author, channel.asChannel(), guild!!)
+        }
+    }
+
+    command("archiveRule") {
+        description = "Archive a rule in this guild."
+        requiredPermissionLevel = PermissionLevel.Administrator
+        execute {
+            conversationService.startPublicConversation<ArchiveRuleConversation>(author, channel.asChannel(), guild!!)
+        }
+    }
+
+    command("ruleHeadings") {
+        description = "List the rules of this guild."
+        requiredPermissionLevel = PermissionLevel.Everyone
+        execute {
+            respond {
+                createRulesEmbed(guild!!, databaseService.guilds.getRules(guild!!)!!)
+            }
+        }
+    }
+
+    command("listRules") {
+        description = "List the rules of this guild."
+        requiredPermissionLevel = PermissionLevel.Everyone
+        execute {
+            respond {
+                createRulesEmbedDetailed(guild!!, databaseService.guilds.getRules(guild!!)!!)
+            }
+        }
+    }
+
+    command("rule") {
+        description = "List a rule from this guild."
+        requiredPermissionLevel = PermissionLevel.Everyone
+        execute(IntegerArg) {
+            val rule = databaseService.guilds.getRule(guild!!, args.first)!!
+            respond {
+                createRuleEmbed(guild!!, rule)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/me/ddivad/judgebot/conversations/rules/AddRuleConversation.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/conversations/rules/AddRuleConversation.kt
@@ -1,0 +1,37 @@
+package me.ddivad.judgebot.conversations.rules
+
+import com.gitlab.kordlib.core.entity.Guild
+import me.ddivad.judgebot.dataclasses.Configuration
+import me.ddivad.judgebot.dataclasses.Rule
+import me.ddivad.judgebot.embeds.createRuleEmbed
+import me.ddivad.judgebot.services.DatabaseService
+import me.jakejmattson.discordkt.api.arguments.BooleanArg
+import me.jakejmattson.discordkt.api.arguments.EveryArg
+import me.jakejmattson.discordkt.api.arguments.UrlArg
+import me.jakejmattson.discordkt.api.dsl.Conversation
+import me.jakejmattson.discordkt.api.dsl.conversation
+
+class AddRuleConversation(private val configuration: Configuration,
+                          private val databaseService: DatabaseService): Conversation() {
+    @Conversation.Start
+    fun createAddRuleConversation(guild: Guild) = conversation {
+        val rules = databaseService.guilds.getRules(guild)
+        val nextId = rules?.size?.plus(1)!!
+
+        val ruleName = promptMessage(EveryArg, "Please enter rule name:")
+        val ruleText = promptMessage(EveryArg, "Please enter rule text")
+        val addLink = promptMessage(BooleanArg("Add link to rule?", "Y", "N"),
+                "Do you want to add a link to the rule? (Y/N)")
+        val ruleLink = when {
+            addLink -> promptMessage(UrlArg, "Please enter the link")
+            else -> ""
+        }
+
+        val newRule = Rule(nextId, ruleName, ruleText, ruleLink)
+        databaseService.guilds.addRule(guild, newRule)
+        respond("Rule created.")
+        respond{
+            createRuleEmbed(guild, newRule)
+        }
+    }
+}

--- a/src/main/kotlin/me/ddivad/judgebot/conversations/rules/ArchiveRuleConversation.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/conversations/rules/ArchiveRuleConversation.kt
@@ -1,0 +1,23 @@
+package me.ddivad.judgebot.conversations.rules
+
+import com.gitlab.kordlib.core.entity.Guild
+import me.ddivad.judgebot.dataclasses.Configuration
+import me.ddivad.judgebot.dataclasses.Rule
+import me.ddivad.judgebot.services.DatabaseService
+import me.jakejmattson.discordkt.api.arguments.BooleanArg
+import me.jakejmattson.discordkt.api.arguments.EveryArg
+import me.jakejmattson.discordkt.api.arguments.IntegerArg
+import me.jakejmattson.discordkt.api.arguments.UrlArg
+import me.jakejmattson.discordkt.api.dsl.Conversation
+import me.jakejmattson.discordkt.api.dsl.conversation
+
+class ArchiveRuleConversation(private val configuration: Configuration,
+                          private val databaseService: DatabaseService): Conversation() {
+    @Conversation.Start
+    fun createArchiveRuleConversation(guild: Guild) = conversation {
+        val ruleToArchive = promptMessage(IntegerArg, "Please enter rule number to archive:")
+
+        databaseService.guilds.archiveRule(guild, ruleToArchive)
+        respond("Rule archived.")
+    }
+}

--- a/src/main/kotlin/me/ddivad/judgebot/conversations/rules/EditRuleConversation.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/conversations/rules/EditRuleConversation.kt
@@ -1,0 +1,64 @@
+package me.ddivad.judgebot.conversations.rules
+
+import com.gitlab.kordlib.core.entity.Guild
+import me.ddivad.judgebot.dataclasses.Configuration
+import me.ddivad.judgebot.dataclasses.Rule
+import me.ddivad.judgebot.services.DatabaseService
+import me.jakejmattson.discordkt.api.arguments.BooleanArg
+import me.jakejmattson.discordkt.api.arguments.EveryArg
+import me.jakejmattson.discordkt.api.arguments.IntegerArg
+import me.jakejmattson.discordkt.api.arguments.UrlArg
+import me.jakejmattson.discordkt.api.dsl.Conversation
+import me.jakejmattson.discordkt.api.dsl.conversation
+
+class EditRuleConversation(private val configuration: Configuration,
+                           private val databaseService: DatabaseService) : Conversation() {
+    @Conversation.Start
+    fun createAddRuleConversation(guild: Guild) = conversation {
+        val rules = databaseService.guilds.getRules(guild)
+        val ruleNumberToUpdate = promptMessage(IntegerArg, "Which rule would you like to update?")
+        // TODO: rule embed for chosen rule here
+        val ruleToUpdate = rules?.find { it.number == ruleNumberToUpdate }
+
+        val updateNumber = promptMessage(BooleanArg(truthValue = "y", falseValue = "n"),
+                "Update Rule number? (Y/N)")
+        val ruleNumber = when {
+            updateNumber -> promptUntil(
+                    argumentType = IntegerArg,
+                    prompt = "Please enter rule number:",
+                    isValid = { number -> !rules?.any { it.number == number }!! },
+                    error = "Rule with that number already exists"
+            )
+            else -> ruleToUpdate!!.number
+        }
+        val updateName = promptMessage(BooleanArg(truthValue = "y", falseValue = "n"),
+                "Update Rule name? (Y/N)")
+        val ruleName = when {
+            updateName -> promptUntil(
+                    EveryArg,
+                    "Please enter rule name:",
+                    "Rule with that name already exists",
+                    isValid = { name -> !rules?.any { it.title == name }!! }
+            )
+            else -> ruleToUpdate!!.title
+        }
+
+        val updateText = promptMessage(BooleanArg(truthValue = "y", falseValue = "n"),
+                "Update Rule text? (Y/N)")
+        val ruleText = when {
+            updateText -> promptMessage(EveryArg, "Please enter rule text:")
+            else -> ruleToUpdate!!.description
+        }
+
+        val updateLink = promptMessage(BooleanArg(truthValue = "y", falseValue = "n"),
+                "Update Rule link? (Y/N)")
+        val ruleLink = when {
+            updateLink -> promptMessage(UrlArg, "Please enter the link")
+            else -> ruleToUpdate!!.link
+        }
+
+        val newRule = Rule(ruleNumber, ruleName, ruleText, ruleLink, ruleToUpdate!!.archived)
+        databaseService.guilds.editRule(guild, ruleToUpdate, newRule)
+        respond("Rule edited.")
+    }
+}

--- a/src/main/kotlin/me/ddivad/judgebot/dataclasses/GuildInformation.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/dataclasses/GuildInformation.kt
@@ -1,0 +1,32 @@
+package me.ddivad.judgebot.dataclasses
+
+data class GuildInformation(
+        val guildId: String,
+        val rules: MutableList<Rule> = mutableListOf()
+) {
+    fun addRule(rule: Rule) {
+        this.rules.add(rule)
+    }
+
+    fun getRuleById(ruleNumber: Int): Rule? {
+        return this.rules.firstOrNull { it.number == ruleNumber }
+    }
+
+    fun archiveRule(ruleNumber: Int) {
+        this.rules.find { it.number == ruleNumber }!!.archived = true
+    }
+
+    fun editRule(oldRule: Rule, updatedRule: Rule): Rule {
+        val index = this.rules.indexOf(oldRule)
+        this.rules[index] = updatedRule
+        return updatedRule
+    }
+}
+
+data class Rule(
+        val number: Int,
+        val title: String,
+        val description: String,
+        val link: String,
+        var archived: Boolean = false
+)

--- a/src/main/kotlin/me/ddivad/judgebot/embeds/RuleEmbeds.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/embeds/RuleEmbeds.kt
@@ -1,0 +1,52 @@
+package me.ddivad.judgebot.embeds
+
+import com.gitlab.kordlib.core.entity.Guild
+import com.gitlab.kordlib.rest.builder.message.EmbedBuilder
+import me.ddivad.judgebot.dataclasses.Rule
+import me.jakejmattson.discordkt.api.extensions.addField
+import java.awt.Color
+import com.gitlab.kordlib.rest.Image
+
+fun EmbedBuilder.createRuleEmbed(guild: Guild, rule: Rule) {
+    title = "__${rule.number}: ${rule.title}__"
+    description = rule.description
+    thumbnail {
+        url = guild.getIconUrl(Image.Format.PNG) ?: ""
+    }
+    if(rule.link !== "") {
+        addField("", "[View this on our website](${rule.link})")
+    }
+    color = Color.MAGENTA
+}
+
+fun EmbedBuilder.createRulesEmbed(guild: Guild, rules: List<Rule>) {
+    title = "**__Server Rules__**"
+    thumbnail {
+        url = guild.getIconUrl(Image.Format.PNG) ?: ""
+    }
+    color = Color.MAGENTA
+
+    field {
+        for (rule in rules) {
+            value += "**[${rule.number}](${rule.link})**. ${rule.title}\n"
+        }
+    }
+    footer {
+        text = guild.name
+    }
+}
+
+fun EmbedBuilder.createRulesEmbedDetailed(guild: Guild, rules: List<Rule>) {
+    title = "**__Rules__**"
+    thumbnail {
+        url = guild.getIconUrl(Image.Format.PNG) ?: ""
+    }
+    color = Color.MAGENTA
+
+    for (rule in rules) {
+        field {
+            value = "**__${rule.number}: ${rule.title}__**\n${rule.description}"
+            inline = false
+        }
+    }
+}

--- a/src/main/kotlin/me/ddivad/judgebot/services/DatabaseService.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/services/DatabaseService.kt
@@ -1,10 +1,12 @@
 package me.ddivad.judgebot.services
 
 import me.ddivad.judgebot.dataclasses.Configuration
+import me.ddivad.judgebot.services.database.GuildOperations
 import me.ddivad.judgebot.services.database.UserOperations
 import me.jakejmattson.discordkt.api.annotations.Service
 
 @Service
 open class DatabaseService(val config: Configuration,
-                           val users: UserOperations) {
+                           val users: UserOperations,
+                           val guilds: GuildOperations) {
 }

--- a/src/main/kotlin/me/ddivad/judgebot/services/database/GuildOperations.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/services/database/GuildOperations.kt
@@ -1,0 +1,62 @@
+package me.ddivad.judgebot.services.database
+
+import com.gitlab.kordlib.core.entity.Guild
+import kotlinx.coroutines.runBlocking
+import me.ddivad.judgebot.dataclasses.GuildInformation
+import me.ddivad.judgebot.dataclasses.Rule
+import me.jakejmattson.discordkt.api.annotations.Service
+import org.litote.kmongo.eq
+
+// Note: RunBlocking is needed for DB operations in this service, as they are used in a conversation (which does not support "suspend" functions)
+
+@Service
+class GuildOperations(private val connection: ConnectionService) {
+    private val guildCollection = connection.db.getCollection<GuildInformation>("Guilds")
+
+    suspend fun setupGuild(guild: Guild): GuildInformation {
+        val guildConfig = GuildInformation(guild.id.value)
+        this.guildCollection.insertOne(guildConfig)
+        return guildConfig
+    }
+
+    suspend fun getRules(guild: Guild): List<Rule>? {
+        return runBlocking {
+            guildCollection.findOne(GuildInformation::guildId eq guild.id.value)?.rules?.sortedBy { it.number }
+        }
+    }
+
+    suspend fun getRule(guild: Guild, ruleId: Int): Rule? {
+        return runBlocking {
+            guildCollection.findOne(GuildInformation::guildId eq guild.id.value)?.rules?.find { it.number == ruleId }
+        }
+    }
+
+    fun addRule(guild: Guild, rule: Rule) {
+        runBlocking {
+            val guildInfo = guildCollection.findOne(GuildInformation::guildId eq guild.id.value)
+            guildInfo!!.addRule(rule)
+            updateGuild(guildInfo)
+        }
+    }
+
+    fun editRule(guild: Guild, oldRule: Rule, updatedRule: Rule) {
+        runBlocking {
+            val guildInfo = guildCollection.findOne(GuildInformation::guildId eq guild.id.value)
+            guildInfo!!.editRule(oldRule, updatedRule)
+            updateGuild(guildInfo)
+        }
+    }
+
+    fun archiveRule(guild: Guild, ruleNumber: Int) {
+        runBlocking {
+            val guildInfo = guildCollection.findOne(GuildInformation::guildId eq guild.id.value)
+            guildInfo!!.archiveRule(ruleNumber)
+            updateGuild(guildInfo)
+        }
+    }
+
+    private suspend fun updateGuild(guildInformation: GuildInformation): GuildInformation {
+        guildCollection.updateOne(GuildInformation::guildId eq guildInformation.guildId, guildInformation)
+        return guildInformation
+    }
+}


### PR DESCRIPTION
# feat: add rules implementation

Add intial rules implementation. This includes the ability to create, view, edit and archive rules.

Added:
- GuildInformation class. This stores a guild and its list of rules (wil store things like bans in the future).
- Add new rule commands to manage rules.
- Add new embeds to show rule details.
- Add new database operations (GuildOperations) to allow the rules functionality to work.