### PR TITLE
feat: add mute functionality

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -12,20 +12,30 @@
 | setadminrole    | Role         | Set the bot admin role.                           |
 | setalertchannel | Text Channel | Set the channel that the bot alerts will be sent. |
 | setlogchannel   | Text Channel | Set the channel that the bot logs will be sent.   |
+| setmuterole     | Role         | Set the role to be used to mute members.          |
 | setprefix       | Text         | Set the bot prefix.                               |
 | setstaffrole    | Role         | Set the bot staff role.                           |
 
 ## Infraction
-| Commands  | Arguments               | Description    |
-| --------- | ----------------------- | -------------- |
-| strike, s | Member, (Integer), Text | Strike a user. |
-| warn, w   | Member, Text            | Warn a user.   |
+| Commands  | Arguments               | Description                                             |
+| --------- | ----------------------- | ------------------------------------------------------- |
+| cleanse   | Member                  | Use this to delete (permanently) as user's infractions. |
+| strike, s | Member, (Integer), Text | Strike a user.                                          |
+| warn, w   | Member, Text            | Warn a user.                                            |
+
+## Mute
+| Commands | Arguments          | Description                                             |
+| -------- | ------------------ | ------------------------------------------------------- |
+| gag      | Member             | Mute a user for 5 minutes while you deal with something |
+| mute     | Member, Time, Text | Mute a user for a specified time.                       |
+| unmute   | Member             | Unmute a user.                                          |
 
 ## Notes
-| Commands   | Arguments            | Description                                  |
-| ---------- | -------------------- | -------------------------------------------- |
-| deleteNote | Member, Integer      | Use this to add a delete a note from a user. |
-| note       | Member, Note Content | Use this to add a note to a user.            |
+| Commands     | Arguments            | Description                                       |
+| ------------ | -------------------- | ------------------------------------------------- |
+| cleansenotes | Member               | Use this to delete (permanently) as user's notes. |
+| deleteNote   | Member, Integer      | Use this to add a delete a note from a user.      |
+| note         | Member, Note Content | Use this to add a note to a user.                 |
 
 ## Rules
 | Commands     | Arguments | Description                   |

--- a/src/main/kotlin/me/ddivad/judgebot/Main.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/Main.kt
@@ -1,7 +1,5 @@
 package me.ddivad.judgebot
 
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.json.Json
 import me.ddivad.judgebot.dataclasses.Configuration
 import me.ddivad.judgebot.services.BotStatsService
 import me.ddivad.judgebot.services.PermissionsService
@@ -9,7 +7,6 @@ import me.ddivad.judgebot.services.requiredPermissionLevel
 import me.jakejmattson.discordkt.api.dsl.bot
 import me.jakejmattson.discordkt.api.extensions.addInlineField
 import java.awt.Color
-import java.util.*
 
 suspend fun main(args: Array<String>) {
     val token = args.firstOrNull()

--- a/src/main/kotlin/me/ddivad/judgebot/commands/GuildConfigCommands.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/commands/GuildConfigCommands.kt
@@ -101,4 +101,18 @@ fun guildConfigCommands(configuration: Configuration,
             respond("Channel set to: **${channel.name}**")
         }
     }
+
+    command("setmuterole") {
+        description = "Set the role to be used to mute members."
+        requiredPermissionLevel = PermissionLevel.Administrator
+        execute(RoleArg) {
+            if (!configuration.hasGuildConfig(guild!!.id.longValue))
+                return@execute respond("Please run the **configure** command to set this initially.")
+
+            val role = args.first
+            configuration[guild!!.id.longValue]?.mutedRole = role.id.value
+            configuration.save()
+            respond("Role set to: **${role.name}**")
+        }
+    }
 }

--- a/src/main/kotlin/me/ddivad/judgebot/commands/InfractionCommands.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/commands/InfractionCommands.kt
@@ -4,10 +4,8 @@ import me.ddivad.judgebot.dataclasses.Configuration
 import me.ddivad.judgebot.dataclasses.Infraction
 import me.ddivad.judgebot.dataclasses.InfractionType
 import me.ddivad.judgebot.embeds.createHistoryEmbed
-import me.ddivad.judgebot.services.DatabaseService
-import me.ddivad.judgebot.services.PermissionLevel
+import me.ddivad.judgebot.services.*
 import me.ddivad.judgebot.services.infractions.InfractionService
-import me.ddivad.judgebot.services.requiredPermissionLevel
 import me.jakejmattson.discordkt.api.arguments.EveryArg
 import me.jakejmattson.discordkt.api.arguments.IntegerArg
 import me.jakejmattson.discordkt.api.arguments.MemberArg
@@ -15,13 +13,15 @@ import me.jakejmattson.discordkt.api.dsl.commands
 
 fun createInfractonCommands(databaseService: DatabaseService,
                             config: Configuration,
-                            infractionService: InfractionService) = commands("Infraction") {
+                            infractionService: InfractionService,
+                            roleService: MuteService) = commands("Infraction") {
     command("strike", "s") {
         description = "Strike a user."
         requiresGuild = true
         requiredPermissionLevel = PermissionLevel.Staff
         execute(MemberArg, IntegerArg.makeOptional(1), EveryArg) {
             val user = databaseService.users.getOrCreateUser(args.first, guild!!.id.value)
+            createHistoryEmbed(args.first, user, guild!!, config, true)
         }
     }
 
@@ -34,6 +34,18 @@ fun createInfractonCommands(databaseService: DatabaseService,
             val infraction = Infraction(this.author.id.value, args.second, InfractionType.Warn)
             infractionService.infract(args.first, guild!!, user, infraction)
             createHistoryEmbed(args.first, user, guild!!, config, true)
+        }
+    }
+
+    command("cleanse") {
+        description = "Use this to delete (permanently) as user's infractions."
+        requiresGuild = true
+        requiredPermissionLevel = PermissionLevel.Administrator
+        execute(MemberArg) {
+            val user = databaseService.users.getOrCreateUser(args.first, guild!!.id.value)
+            if (user.getGuildInfo(guild!!.id.value)!!.infractions.isEmpty()) return@execute respond("User has no infractions.")
+            databaseService.users.cleanseInfractions(guild!!, user)
+            respond("Infractions cleansed.")
         }
     }
 }

--- a/src/main/kotlin/me/ddivad/judgebot/commands/MuteCommands.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/commands/MuteCommands.kt
@@ -1,0 +1,48 @@
+package me.ddivad.judgebot.commands
+
+import me.ddivad.judgebot.dataclasses.InfractionType
+import me.ddivad.judgebot.services.*
+import me.jakejmattson.discordkt.api.arguments.EveryArg
+import me.jakejmattson.discordkt.api.arguments.MemberArg
+import me.jakejmattson.discordkt.api.arguments.TimeArg
+import me.jakejmattson.discordkt.api.dsl.commands
+import kotlin.math.roundToLong
+
+fun createMuteCommands(muteService: MuteService) = commands("Mute") {
+    command("mute") {
+        description = "Mute a user for a specified time."
+        requiresGuild = true
+        requiredPermissionLevel = PermissionLevel.Staff
+        execute(MemberArg, TimeArg, EveryArg) {
+            muteService.applyMute(args.first, args.second.roundToLong() * 1000, args.third, InfractionType.Mute)
+            respond("User ${args.first.username} has been muted")
+        }
+    }
+
+    command("unmute") {
+        description = "Unmute a user."
+        requiresGuild = true
+        requiredPermissionLevel = PermissionLevel.Staff
+        execute(MemberArg) {
+            val targetMember = args.first
+            if (muteService.checkRoleState(targetMember, InfractionType.Mute) == RoleState.None)
+                return@execute respond("User ${targetMember.mention} isn't muted")
+
+            muteService.removeMute(targetMember, InfractionType.Mute)
+            respond("User ${args.first.username} has been unmuted")
+        }
+    }
+
+    command("gag") {
+        description = "Mute a user for 5 minutes while you deal with something"
+        requiresGuild = true
+        requiredPermissionLevel = PermissionLevel.Staff
+        execute(MemberArg) {
+            muteService.applyMute(
+                    args.first,
+                    1000 * 60 * 5,
+                    "You've been muted temporarily so that a mod can handle something.",
+                    InfractionType.Mute)
+        }
+    }
+}

--- a/src/main/kotlin/me/ddivad/judgebot/commands/NoteCommands.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/commands/NoteCommands.kt
@@ -34,4 +34,16 @@ fun noteCommands(databaseService: DatabaseService, configuration: Configuration)
             respond("Note deleted.")
         }
     }
+
+    command("cleansenotes") {
+        description = "Use this to delete (permanently) as user's notes."
+        requiresGuild = true
+        requiredPermissionLevel = PermissionLevel.Administrator
+        execute(MemberArg) {
+            val user = databaseService.users.getOrCreateUser(args.first, guild!!.id.value)
+            if (user.getGuildInfo(guild!!.id.value)!!.notes.isEmpty()) return@execute respond("User has no notes.")
+            databaseService.users.cleanseNotes(guild!!, user)
+            respond("Notes cleansed.")
+        }
+    }
 }

--- a/src/main/kotlin/me/ddivad/judgebot/conversations/GuildConfigConversation.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/conversations/GuildConfigConversation.kt
@@ -17,7 +17,15 @@ class ConfigurationConversation(private val configuration: Configuration): Conve
         val staffRole = promptMessage(RoleArg, "Staff role:")
         val logChannel = promptMessage(ChannelArg, "Log Channel:")
         val alertChannel = promptMessage(ChannelArg, "Alert Channel:")
+        val mutedRole = promptMessage(RoleArg, "Muted role:")
 
-        configuration.setup(guild, prefix, adminRole, staffRole, LoggingConfiguration(logChannel.id.value, alertChannel.id.value))
+        configuration.setup(
+                guild,
+                prefix,
+                adminRole,
+                staffRole,
+                mutedRole,
+                LoggingConfiguration(logChannel.id.value, alertChannel.id.value),
+        )
     }
 }

--- a/src/main/kotlin/me/ddivad/judgebot/dataclasses/Configuration.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/dataclasses/Configuration.kt
@@ -13,7 +13,7 @@ data class Configuration(
     operator fun get(id: Long) = guildConfigurations[id]
     fun hasGuildConfig(guildId: Long) = guildConfigurations.containsKey(guildId)
 
-    fun setup(guild: Guild, prefix: String, adminRole: Role, staffRole: Role, logging: LoggingConfiguration) {
+    fun setup(guild: Guild, prefix: String, adminRole: Role, staffRole: Role, mutedRole: Role, logging: LoggingConfiguration) {
         if (guildConfigurations[guild.id.longValue] != null) return
 
         val newConfiguration = GuildConfiguration(
@@ -21,6 +21,7 @@ data class Configuration(
                 prefix,
                 staffRole.id.value,
                 adminRole.id.value,
+                mutedRole.id.value,
                 logging
         )
         guildConfigurations[guild.id.longValue] = newConfiguration
@@ -29,7 +30,7 @@ data class Configuration(
 }
 
 data class DatabaseConfiguration(
-        val address: String = "localhost:27017",
+        val address: String = "mongodb://localhost:27017",
         val databaseName: String = "judgebot"
 )
 
@@ -38,6 +39,7 @@ data class GuildConfiguration(
         var prefix: String = "j!",
         var staffRole: String = "",
         var adminRole: String = "",
+        var mutedRole: String = "",
         var loggingConfiguration: LoggingConfiguration = LoggingConfiguration()
 )
 

--- a/src/main/kotlin/me/ddivad/judgebot/dataclasses/GuildInformation.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/dataclasses/GuildInformation.kt
@@ -2,7 +2,9 @@ package me.ddivad.judgebot.dataclasses
 
 data class GuildInformation(
         val guildId: String,
-        val rules: MutableList<Rule> = mutableListOf()
+        val guildName: String,
+        val rules: MutableList<Rule> = mutableListOf(),
+        val punishments: MutableList<Punishment> = mutableListOf()
 ) {
     fun addRule(rule: Rule) {
         this.rules.add(rule)
@@ -20,6 +22,20 @@ data class GuildInformation(
         val index = this.rules.indexOf(oldRule)
         this.rules[index] = updatedRule
         return updatedRule
+    }
+
+    fun addPunishment(punishment: Punishment) {
+        punishment.id = this.punishments.size + 1
+        this.punishments.add(punishment)
+    }
+
+    fun removePunishment(userId: String, type: InfractionType) {
+        val punishment = this.findPunishmentByType(type, userId).first()
+        this.punishments.remove(punishment)
+    }
+
+    fun findPunishmentByType(type: InfractionType, userId: String): List<Punishment> {
+        return this.punishments.filter { it.type == type && it.userId == userId }
     }
 }
 

--- a/src/main/kotlin/me/ddivad/judgebot/dataclasses/GuildMember.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/dataclasses/GuildMember.kt
@@ -5,7 +5,7 @@ import org.joda.time.DateTime
 
 data class GuildDetails(
         val guildId: String,
-        val notes: MutableList<Note> = mutableListOf<Note>(),
+        var notes: MutableList<Note> = mutableListOf<Note>(),
         val infractions: MutableList<Infraction> = mutableListOf<Infraction>(),
         var historyCount: Int = 0,
         var points: Int = 0,
@@ -23,6 +23,14 @@ data class GuildMember(
 
     fun deleteNote(noteId: Int, guild: Guild) = with(this.getGuildInfo(guild.id.value)) {
         this?.notes?.removeIf { it.id == noteId }
+    }
+
+    fun cleanseNotes(guild: Guild) = with(this.getGuildInfo(guild.id.value)) {
+        this?.notes?.clear()
+    }
+
+    fun cleanseInfractions(guild: Guild) = with(this.getGuildInfo(guild.id.value)) {
+        this?.infractions?.clear()
     }
 
     fun addInfraction(infraction: Infraction, guild:Guild) = with(this.getGuildInfo(guild.id.value)) {

--- a/src/main/kotlin/me/ddivad/judgebot/dataclasses/Infraction.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/dataclasses/Infraction.kt
@@ -3,13 +3,13 @@ package me.ddivad.judgebot.dataclasses
 import java.util.*
 
 enum class InfractionType {
-    Warn, Strike
+    Warn, Strike, Mute, BadPfp
 }
 
 data class Infraction(
         val moderator: String,
         val reason: String,
-        val weight: InfractionType,
+        val type: InfractionType,
         val strikes: Int = 0,
         val dateTime: Long = Date().time
 )

--- a/src/main/kotlin/me/ddivad/judgebot/dataclasses/Punishment.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/dataclasses/Punishment.kt
@@ -1,11 +1,7 @@
 package me.ddivad.judgebot.dataclasses
 
-enum class PunishmentType {
-    Warn, Mute, BadPfp, Strike
-}
-
 data class Punishment(val userId: String,
-                      val guildId: String,
-                      val type: PunishmentType,
+                      val type: InfractionType,
                       var reason: String,
-                      val clearTime: Long)
+                      val clearTime: Long,
+                      var id: Int = 0)

--- a/src/main/kotlin/me/ddivad/judgebot/embeds/UserEmbeds.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/embeds/UserEmbeds.kt
@@ -37,7 +37,7 @@ suspend fun CommandEvent<*>.createHistoryEmbed(target: Member,
         addField("", "")
         addField(
                 "**__Most Recent Infraction__**",
-                "Type: **${lastInfraction.weight}** :: Weight: **${lastInfraction.strikes}**\n " +
+                "Type: **${lastInfraction.type}** :: Weight: **${lastInfraction.strikes}**\n " +
                         "Issued by **${guild.kord.getUser(Snowflake(lastInfraction.moderator))?.username}** " +
                         "on **${SimpleDateFormat("dd/MM/yyyy").format(Date(lastInfraction.dateTime))}**\n" +
                         lastInfraction.reason

--- a/src/main/kotlin/me/ddivad/judgebot/services/MuteService.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/services/MuteService.kt
@@ -1,0 +1,110 @@
+package me.ddivad.judgebot.services
+
+import com.gitlab.kordlib.common.entity.Permission
+import com.gitlab.kordlib.common.entity.Permissions
+import com.gitlab.kordlib.core.entity.Guild
+import com.gitlab.kordlib.core.entity.Member
+import com.gitlab.kordlib.core.entity.PermissionOverwrite
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import me.ddivad.judgebot.dataclasses.Configuration
+import me.ddivad.judgebot.dataclasses.InfractionType
+import me.ddivad.judgebot.dataclasses.Punishment
+import me.ddivad.judgebot.util.applyRoleWithTimer
+import me.jakejmattson.discordkt.api.Discord
+import me.jakejmattson.discordkt.api.annotations.Service
+import me.jakejmattson.discordkt.api.extensions.toSnowflake
+import org.joda.time.DateTime
+
+typealias GuildID = String
+typealias UserId = String
+
+enum class RoleState {
+    None,
+    Tracked,
+    Untracked,
+}
+
+@Service
+class MuteService(val configuration: Configuration,
+                  private val discord: Discord,
+                  private val databaseService: DatabaseService) {
+    private val punishmentTimerMap = hashMapOf<Pair<GuildID, UserId>, Job>()
+    private suspend fun toKey(member: Member) = member.guild.id.value to member.asUser().id.value
+    private suspend fun getMutedRole(guild: Guild) = guild.getRole(configuration[guild.id.longValue]?.mutedRole?.toSnowflake()!!)
+
+    init {
+        runBlocking {
+            configuration.guildConfigurations.forEach { config ->
+                val guild = config.value.id.toSnowflake()?.let { discord.api.getGuild(it) } ?: return@forEach
+                handleExistingMutes(guild)
+                setupMutedRole(guild)
+            }
+        }
+    }
+
+    suspend fun applyMute(member: Member, time: Long, reason: String, type: InfractionType) {
+        val guild = member.guild.asGuild()
+        val userId = member.asUser().id.value
+        val key = toKey(member)
+        val clearTime = DateTime.now().plus(time).millis
+
+        if (key in punishmentTimerMap) {
+            punishmentTimerMap[key]?.cancel()
+            punishmentTimerMap.remove(key)
+        }
+        val punishment = Punishment(userId, type, reason, clearTime)
+        databaseService.guilds.addPunishment(guild.asGuild(), punishment)
+        punishmentTimerMap[toKey(member)] = applyRoleWithTimer(member, getMutedRole(guild), time) {
+            removeMute(member, type)
+        }
+    }
+
+    fun removeMute(member: Member, type: InfractionType) {
+        runBlocking {
+            val guild = member.guild.asGuild()
+            val key = toKey(member)
+            member.removeRole(getMutedRole(guild).id)
+            databaseService.guilds.removePunishment(guild, member.asUser().id.value, type)
+            punishmentTimerMap[key]?.cancel()
+            punishmentTimerMap.remove(toKey(member))
+        }
+    }
+
+    private suspend fun handleExistingMutes(guild: Guild) {
+        databaseService.guilds.getPunishmentsForGuild(guild).forEach {
+            val difference = it.clearTime - DateTime.now().millis
+            val member = guild.getMember(it.userId.toSnowflake()!!)
+            applyRoleWithTimer(member, getMutedRole(guild), difference) { _ ->
+                removeMute(member, it.type)
+            }
+        }
+    }
+
+    suspend fun checkRoleState(member: Member, type: InfractionType) = when {
+        databaseService.guilds.checkPunishmentExists(member, type).isNotEmpty() -> RoleState.Tracked
+        member.roles.toList().contains(getMutedRole(member.getGuild())) -> RoleState.Untracked
+        else -> RoleState.None
+    }
+
+    private suspend fun setupMutedRole(guild: Guild) {
+        val mutedRole = guild.getRole(configuration[guild.id.longValue]!!.mutedRole.toSnowflake()!!)
+        guild.channels.toList().forEach {
+            val deniedPermissions = it.getPermissionOverwritesForRole(mutedRole.id)?.denied
+            if (deniedPermissions == null) {
+                val permissions = Permissions().plus(Permission.AddReactions).plus(Permission.SendMessages)
+                it.addOverwrite(PermissionOverwrite.forRole(
+                        mutedRole.id,
+                        denied = permissions))
+            } else if (!deniedPermissions.contains(Permission.SendMessages) || !deniedPermissions.contains(Permission.AddReactions)) {
+                it.addOverwrite(
+                        PermissionOverwrite.forRole(
+                                mutedRole.id,
+                                denied = deniedPermissions.plus(Permission.SendMessages).plus(Permission.AddReactions))
+                )
+            }
+        }
+    }
+}

--- a/src/main/kotlin/me/ddivad/judgebot/services/database/ConnectionService.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/services/database/ConnectionService.kt
@@ -1,7 +1,5 @@
 package me.ddivad.judgebot.services.database
 
-import com.mongodb.reactivestreams.client.MongoClient
-import com.mongodb.reactivestreams.client.MongoDatabase
 import me.ddivad.judgebot.dataclasses.Configuration
 import me.jakejmattson.discordkt.api.annotations.Service
 import org.litote.kmongo.coroutine.CoroutineClient

--- a/src/main/kotlin/me/ddivad/judgebot/services/database/UserOperations.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/services/database/UserOperations.kt
@@ -41,8 +41,18 @@ class UserOperations(private val connection: ConnectionService) {
         return this.updateUser(user)
     }
 
+    suspend fun cleanseNotes(guild: Guild, user: GuildMember): GuildMember {
+        user.cleanseNotes(guild)
+        return this.updateUser(user)
+    }
+
     suspend fun addInfraction(guild: Guild, user: GuildMember, infraction: Infraction): GuildMember {
         user.addInfraction(infraction, guild)
+        return this.updateUser(user)
+    }
+
+    suspend fun cleanseInfractions(guild: Guild, user: GuildMember): GuildMember {
+        user.cleanseInfractions(guild)
         return this.updateUser(user)
     }
 

--- a/src/main/kotlin/me/ddivad/judgebot/util/TimerUtils.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/util/TimerUtils.kt
@@ -1,0 +1,16 @@
+package me.ddivad.judgebot.util
+
+import com.gitlab.kordlib.core.entity.Member
+import com.gitlab.kordlib.core.entity.Role
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+suspend fun applyRoleWithTimer(member: Member, role: Role, millis: Long, fn: (Member) -> Unit): Job {
+    member.addRole(role.id)
+    return GlobalScope.launch {
+        delay(millis)
+        fn(member)
+    }
+}


### PR DESCRIPTION
# feat: add mute functionality

Add mute and gag functionality.

Added:
- Mute & gag commands.
- Unmute command.
- Mute service.
- Punishments implementation in the guild collection.
- Guild database operations to manipulate punishments.
- Utility functions to manage timers and mutes.
- Ability to setup muted role with AddReactions & SendMessages permissions disabled.
- Ability to add a muted role via server configuration conversation.
- Cleanse commands to clear notes & infractions for a user.