### PR TITLE
feat: add new channel listener & rejoin mute listener

### DIFF
--- a/src/main/kotlin/me/ddivad/judgebot/commands/MuteCommands.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/commands/MuteCommands.kt
@@ -25,7 +25,7 @@ fun createMuteCommands(muteService: MuteService) = commands("Mute") {
         requiredPermissionLevel = PermissionLevel.Staff
         execute(MemberArg) {
             val targetMember = args.first
-            if (muteService.checkRoleState(targetMember, InfractionType.Mute) == RoleState.None)
+            if (muteService.checkRoleState(guild!!, targetMember, InfractionType.Mute) == RoleState.None)
                 return@execute respond("User ${targetMember.mention} isn't muted")
 
             muteService.removeMute(targetMember, InfractionType.Mute)

--- a/src/main/kotlin/me/ddivad/judgebot/listeners/NewChannelOverrideListener.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/listeners/NewChannelOverrideListener.kt
@@ -1,0 +1,26 @@
+package me.ddivad.judgebot.listeners
+
+import com.gitlab.kordlib.common.entity.Permission
+import com.gitlab.kordlib.common.entity.Permissions
+import com.gitlab.kordlib.core.entity.PermissionOverwrite
+import com.gitlab.kordlib.core.event.channel.TextChannelCreateEvent
+import me.ddivad.judgebot.dataclasses.Configuration
+import me.jakejmattson.discordkt.api.dsl.listeners
+import me.jakejmattson.discordkt.api.extensions.toSnowflake
+
+fun onChannelCreated(configuration: Configuration) = listeners {
+    on<TextChannelCreateEvent> {
+        val channel = this.channel
+        val guild = channel.getGuild()
+        val mutedRole = guild.getRole(configuration[guild.id.longValue]!!.mutedRole.toSnowflake()!!)
+
+        val deniedPermissions = channel.getPermissionOverwritesForRole(mutedRole.id)?.denied ?: Permissions()
+        if (!deniedPermissions.contains(Permission.SendMessages) || !deniedPermissions.contains(Permission.AddReactions)) {
+            channel.addOverwrite(
+                    PermissionOverwrite.forRole(
+                            mutedRole.id,
+                            denied = deniedPermissions.plus(Permission.SendMessages).plus(Permission.AddReactions))
+            )
+        }
+    }
+}

--- a/src/main/kotlin/me/ddivad/judgebot/listeners/RejoinMuteListener.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/listeners/RejoinMuteListener.kt
@@ -1,0 +1,20 @@
+package me.ddivad.judgebot.listeners
+
+import com.gitlab.kordlib.core.event.guild.MemberJoinEvent
+import kotlinx.coroutines.runBlocking
+import me.ddivad.judgebot.dataclasses.InfractionType
+import me.ddivad.judgebot.services.MuteService
+import me.ddivad.judgebot.services.RoleState
+import me.jakejmattson.discordkt.api.dsl.listeners
+
+fun onMemberRejoinWithMute(muteService: MuteService) = listeners {
+    on<MemberJoinEvent> {
+        val member = this.member
+        val guild = this.getGuild()
+        runBlocking {
+            if (muteService.checkRoleState(guild, member, InfractionType.Mute) == RoleState.Tracked) {
+                muteService.handleRejoinMute(guild, member)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/me/ddivad/judgebot/services/database/GuildOperations.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/services/database/GuildOperations.kt
@@ -71,8 +71,8 @@ class GuildOperations(private val connection: ConnectionService) {
         updateGuild(guildInfo)
     }
 
-    suspend fun checkPunishmentExists(member: Member, type: InfractionType): List<Punishment> {
-        val guildInfo = guildCollection.findOne(GuildInformation::guildId eq member.getGuild().id.value)
+    suspend fun checkPunishmentExists(guild: Guild, member: Member, type: InfractionType): List<Punishment> {
+        val guildInfo = guildCollection.findOne(GuildInformation::guildId eq guild.asGuild().id.value)
         return guildInfo!!.findPunishmentByType(type, member.asUser().id.value)
     }
 


### PR DESCRIPTION
# feat: add new channel listener & rejoin mute listener

Add listeners to the bot to check for mutes on members rejoining and add overrides for the muted role when new channels are made.

Added:
- NewChannelOverride listener and RejoinMute listener.
- Updated mute service to handle rejoin mutes.
- Fix bug when restarting bot after a muted member has left the server.