### PR TITLE
feat: add reaction listeners for certain events

### DIFF
--- a/src/main/kotlin/me/ddivad/judgebot/Main.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/Main.kt
@@ -55,7 +55,7 @@ suspend fun main(args: Array<String>) {
             field {
                 name = "Build Info"
                 value = "```" +
-                        "Version:   1.0.0-Beta-3\n" +
+                        "Version:   1.0.0-Beta-4\n" +
                         "DiscordKt: ${versions.library}\n" +
                         "Kotlin:    $kotlinVersion" +
                         "```"

--- a/src/main/kotlin/me/ddivad/judgebot/arguments/GuildConfigArg.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/arguments/GuildConfigArg.kt
@@ -13,6 +13,11 @@ val validConfigParameters = mutableListOf(
         "setMuteRole",
         "setLogChannel",
         "setAlertChannel",
+        "setGagReaction",
+        "setHistoryReaction",
+        "setDeleteMessageReaction",
+        "setFlagMessageReaction",
+        "enableReactions",
         "view",
         "options"
 )

--- a/src/main/kotlin/me/ddivad/judgebot/conversations/guild/EditConfigConversation.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/conversations/guild/EditConfigConversation.kt
@@ -5,9 +5,7 @@ import com.gitlab.kordlib.core.entity.channel.TextChannel
 import me.ddivad.judgebot.dataclasses.Configuration
 import me.ddivad.judgebot.embeds.createConfigEmbed
 import me.ddivad.judgebot.embeds.createConfigOptionsEmbed
-import me.jakejmattson.discordkt.api.arguments.ChannelArg
-import me.jakejmattson.discordkt.api.arguments.EveryArg
-import me.jakejmattson.discordkt.api.arguments.RoleArg
+import me.jakejmattson.discordkt.api.arguments.*
 import me.jakejmattson.discordkt.api.dsl.conversation
 
 class EditConfigConversation(private val configuration: Configuration) {
@@ -43,6 +41,31 @@ class EditConfigConversation(private val configuration: Configuration) {
                 val prefix = promptMessage(EveryArg, "Enter Prefix:")
                 guildConfiguration.prefix = prefix
                 respond("Prefix set to **${prefix}**")
+            }
+            "setgagreaction" -> {
+                val reaction = promptMessage(UnicodeEmojiArg, "Enter Reaction:")
+                guildConfiguration.reactions.gagReaction = reaction.unicode
+                respond("Reaction set to ${reaction.unicode}")
+            }
+            "sethistoryreaction" -> {
+                val reaction = promptMessage(UnicodeEmojiArg, "Enter Reaction:")
+                guildConfiguration.reactions.historyReaction = reaction.unicode
+                respond("Reaction set to ${reaction.unicode}")
+            }
+            "setdeletemessagereaction" -> {
+                val reaction = promptMessage(UnicodeEmojiArg, "Enter Reaction:")
+                guildConfiguration.reactions.deleteMessageReaction = reaction.unicode
+                respond("Reaction set to ${reaction.unicode}")
+            }
+            "setflagmessagereaction" -> {
+                val reaction = promptMessage(UnicodeEmojiArg, "Enter Reaction:")
+                guildConfiguration.reactions.flagMessageReaction = reaction.unicode
+                respond("Reaction set to ${reaction.unicode}")
+            }
+            "enablereactions" -> {
+                val enabled = promptMessage(BooleanArg("reaactions", "enable", "disable"), "enable / disable:")
+                guildConfiguration.reactions.enabled = enabled
+                respond("Reactions set to $enabled")
             }
             "view", "list" -> {
                 respond {

--- a/src/main/kotlin/me/ddivad/judgebot/dataclasses/Configuration.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/dataclasses/Configuration.kt
@@ -52,7 +52,8 @@ data class GuildConfiguration(
         var mutedRole: String = "",
         var loggingConfiguration: LoggingConfiguration = LoggingConfiguration(),
         var infractionConfiguration: InfractionConfiguration = InfractionConfiguration(),
-        var punishments: MutableList<PunishmentLevel> = mutableListOf()
+        var punishments: MutableList<PunishmentLevel> = mutableListOf(),
+        var reactions: ReactionConfiguration = ReactionConfiguration()
 )
 
 data class LoggingConfiguration(
@@ -67,11 +68,19 @@ data class InfractionConfiguration(
         var pointCeiling: Int = 50,
         var strikePoints: Int = 10,
         var warnPoints: Int = 0,
-        var pointDecayPerWeek: Int = 2
+        var pointDecayPerWeek: Int = 2,
 )
 
 data class PunishmentLevel(
         var points: Int = 0,
         var punishment: PunishmentType,
         var duration: Long? = null
+)
+
+data class ReactionConfiguration(
+        var enabled: Boolean = true,
+        var gagReaction: String = "",
+        var historyReaction: String = "",
+        var deleteMessageReaction: String = "",
+        var flagMessageReaction: String = ""
 )

--- a/src/main/kotlin/me/ddivad/judgebot/embeds/GuildEmbeds.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/embeds/GuildEmbeds.kt
@@ -33,6 +33,15 @@ suspend fun EmbedBuilder.createConfigEmbed(config: GuildConfiguration, guild: Gu
     }
 
     field {
+        name = "**Reactions**"
+        value = "Enabled: ${config.reactions.enabled} \n" +
+                "Gag: ${config.reactions.gagReaction} \n" +
+                "History: ${config.reactions.historyReaction} \n" +
+                "Delete Message: ${config.reactions.deleteMessageReaction} \n" +
+                "Flag Message: ${config.reactions.flagMessageReaction}"
+    }
+
+    field {
         name = "**Punishments:**"
         config.punishments.forEach {
             value += "Punishment Type: ${it.punishment} \n" +

--- a/src/main/kotlin/me/ddivad/judgebot/extensions/Kord.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/extensions/Kord.kt
@@ -1,7 +1,10 @@
 package me.ddivad.judgebot.extensions
 
+import com.gitlab.kordlib.core.entity.Message
 import com.gitlab.kordlib.core.entity.User
 
 suspend fun User.testDmStatus() {
     getDmChannel().createMessage("Infraction message incoming").delete()
 }
+
+fun Message.jumpLink(guildId:String) = "https://discord.com/channels/${guildId}/${channel.id.value}/${id.value}"

--- a/src/main/kotlin/me/ddivad/judgebot/listeners/MemberReactionListeners.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/listeners/MemberReactionListeners.kt
@@ -1,0 +1,23 @@
+package me.ddivad.judgebot.listeners
+
+import com.gitlab.kordlib.core.behavior.getChannelOf
+import com.gitlab.kordlib.core.entity.channel.TextChannel
+import com.gitlab.kordlib.core.event.message.ReactionAddEvent
+import me.ddivad.judgebot.dataclasses.Configuration
+import me.ddivad.judgebot.extensions.jumpLink
+import me.jakejmattson.discordkt.api.dsl.listeners
+import me.jakejmattson.discordkt.api.extensions.toSnowflake
+
+fun onMemberReactionAdd(configuration: Configuration) = listeners {
+    on<ReactionAddEvent> {
+        val guild = guild?.asGuildOrNull() ?: return@on
+        val guildConfiguration = configuration[guild.asGuild().id.longValue]
+        if (!guildConfiguration?.reactions!!.enabled) return@on
+
+        if(this.emoji.name == guildConfiguration.reactions.flagMessageReaction) {
+            guild.asGuild().getChannelOf<TextChannel>(guildConfiguration.loggingConfiguration.alertChannel.toSnowflake())
+                    .asChannel().createMessage("User ${user.mention} flagged the message: " +
+                            "${this.message.asMessage().jumpLink(guild.id.value)} in: ${this.channel.mention}")
+        }
+    }
+}

--- a/src/main/kotlin/me/ddivad/judgebot/listeners/StaffReactionListeners.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/listeners/StaffReactionListeners.kt
@@ -1,0 +1,49 @@
+package me.ddivad.judgebot.listeners
+
+import com.gitlab.kordlib.core.event.message.ReactionAddEvent
+import com.gitlab.kordlib.kordx.emoji.Emojis
+import com.gitlab.kordlib.rest.route.Route
+import me.ddivad.judgebot.dataclasses.Configuration
+import me.ddivad.judgebot.embeds.createSelfHistoryEmbed
+import me.ddivad.judgebot.services.DatabaseService
+import me.ddivad.judgebot.services.LoggingService
+import me.ddivad.judgebot.services.PermissionLevel
+import me.ddivad.judgebot.services.PermissionsService
+import me.ddivad.judgebot.services.infractions.MuteService
+import me.jakejmattson.discordkt.api.dsl.listeners
+import me.jakejmattson.discordkt.api.extensions.sendPrivateMessage
+
+fun onStaffReactionAdd(muteService: MuteService,
+                       databaseService: DatabaseService,
+                       permissionsService: PermissionsService,
+                       configuration: Configuration) = listeners {
+    on<ReactionAddEvent> {
+        val guild = guild?.asGuildOrNull() ?: return@on
+        val guildConfiguration = configuration[guild.asGuild().id.longValue]
+        if (!guildConfiguration?.reactions!!.enabled) return@on
+
+        user.asMemberOrNull(guild.id)?.let {
+            if (permissionsService.hasPermission(it, PermissionLevel.Staff)) {
+                val messageAuthor = message.asMessage().author ?: return@on
+                message.deleteReaction(this.emoji)
+
+                when (this.emoji.name) {
+                    guildConfiguration.reactions.gagReaction -> {
+                        muteService.applyMute(message.asMessage().author?.asMemberOrNull(guildId!!)!!, 5000 * 1000L, "Gag")
+                        it.sendPrivateMessage("${messageAuthor.mention} gagged.")
+                    }
+                    guildConfiguration.reactions.historyReaction -> {
+                        val target = databaseService.users.getOrCreateUser(messageAuthor, guild!!.asGuild())
+                        it.sendPrivateMessage { createSelfHistoryEmbed(messageAuthor, target, guild!!.asGuild(), configuration) }
+                    }
+                    guildConfiguration.reactions.deleteMessageReaction -> {
+                        messageAuthor.sendPrivateMessage("Your message with content \n" +
+                                "```${message.asMessage().content}``` " +
+                                "was deleted as it is against our rules.")
+                        message.delete()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/me/ddivad/judgebot/services/PermissionsService.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/services/PermissionsService.kt
@@ -35,7 +35,7 @@ class PermissionsService(private val configuration: Configuration) {
 
     suspend fun getPermissionRank(member: Member) = getPermissionLevel(member).ordinal
 
-    private suspend fun getPermissionLevel(member: Member) =
+    suspend fun getPermissionLevel(member: Member) =
             when {
                 member.isBotOwner() -> PermissionLevel.BotOwner
                 member.isGuildOwner() -> PermissionLevel.GuildOwner
@@ -53,7 +53,7 @@ class PermissionsService(private val configuration: Configuration) {
         return roleIds.contains(role)
     }
 
-    private suspend fun Member.isStaff(): Boolean {
+    suspend fun Member.isStaff(): Boolean {
         val role = configuration[guild.id.longValue]?.staffRole.let { role ->
             guild.roles.filter { it.id.value == role }.first().id
         }


### PR DESCRIPTION
# feat: add reaction listeners for certain events

- Add reaction functionality to allow staff to perform certain actions (history, gag, delete message with reason).
- Add reaction functionality to allow members to flag messages for action to the Alert channel.