### PR TITLE
feat: add back long rules embed

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -35,13 +35,14 @@
 | note         | Member, Note Content    | Use this to add a note to a user.                 |
 
 ## Rules
-| Commands    | Arguments | Description                   |
-| ----------- | --------- | ----------------------------- |
-| addRule     |           | Add a rule to this guild.     |
-| archiveRule |           | Archive a rule in this guild. |
-| editRule    |           | Edit a rule in this guild.    |
-| rule        | Rule      | List a rule from this guild.  |
-| rules       |           | List the rules of this guild. |
+| Commands    | Arguments | Description                                       |
+| ----------- | --------- | ------------------------------------------------- |
+| addRule     |           | Add a rule to this guild.                         |
+| archiveRule |           | Archive a rule in this guild.                     |
+| editRule    |           | Edit a rule in this guild.                        |
+| longRules   |           | List the rules (with descriptions) of this guild. |
+| rule        | Rule      | List a rule from this guild.                      |
+| rules       |           | List the rules of this guild.                     |
 
 ## User
 | Commands     | Arguments                                   | Description                                                |

--- a/src/main/kotlin/me/ddivad/judgebot/commands/RuleCommands.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/commands/RuleCommands.kt
@@ -8,6 +8,7 @@ import me.ddivad.judgebot.dataclasses.Configuration
 import me.ddivad.judgebot.embeds.createRuleEmbed
 import me.ddivad.judgebot.embeds.createRuleEmbedForStrike
 import me.ddivad.judgebot.embeds.createRulesEmbed
+import me.ddivad.judgebot.embeds.createRulesEmbedDetailed
 import me.ddivad.judgebot.services.DatabaseService
 import me.ddivad.judgebot.services.PermissionLevel
 import me.ddivad.judgebot.services.requiredPermissionLevel
@@ -52,6 +53,16 @@ fun ruleCommands(configuration: Configuration,
         execute {
             respond {
                 createRulesEmbed(guild, databaseService.guilds.getRules(guild))
+            }
+        }
+    }
+
+    guildCommand("longRules") {
+        description = "List the rules (with descriptions) of this guild."
+        requiredPermissionLevel = PermissionLevel.Staff
+        execute {
+            respond {
+                createRulesEmbedDetailed(guild, databaseService.guilds.getRules(guild)!!)
             }
         }
     }

--- a/src/main/kotlin/me/ddivad/judgebot/dataclasses/Configuration.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/dataclasses/Configuration.kt
@@ -28,7 +28,7 @@ data class Configuration(
 
         // Setup default punishments
         // TODO: Add configuration commands for this
-        newConfiguration.punishments.add(PunishmentLevel(0, PunishmentType.MUTE, 1000L * 60 * 60 * 1))
+        newConfiguration.punishments.add(PunishmentLevel(0, PunishmentType.NONE, 0L))
         newConfiguration.punishments.add(PunishmentLevel(10, PunishmentType.MUTE, 1000L * 60 * 60 * 1))
         newConfiguration.punishments.add(PunishmentLevel(20, PunishmentType.MUTE, 1000L * 60 * 60 * 12))
         newConfiguration.punishments.add(PunishmentLevel(30, PunishmentType.MUTE, 1000L * 60 * 60 * 24))

--- a/src/main/kotlin/me/ddivad/judgebot/dataclasses/Punishment.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/dataclasses/Punishment.kt
@@ -12,5 +12,5 @@ data class Ban(val userId: String,
                var reason: String)
 
 enum class PunishmentType {
-    MUTE, BAN
+    MUTE, BAN, NONE
 }

--- a/src/main/kotlin/me/ddivad/judgebot/embeds/RuleEmbeds.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/embeds/RuleEmbeds.kt
@@ -70,3 +70,8 @@ fun EmbedBuilder.createRulesEmbedDetailed(guild: Guild, rules: List<Rule>) {
             inline = false
         }
     }
+    footer {
+        icon = guild.getIconUrl(Image.Format.PNG) ?: ""
+        text = guild.name
+    }
+}

--- a/src/main/kotlin/me/ddivad/judgebot/embeds/RuleEmbeds.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/embeds/RuleEmbeds.kt
@@ -56,3 +56,17 @@ suspend fun EmbedBuilder.createRuleEmbedForStrike(guild: Guild, rules: List<Rule
         text = guild.name
     }
 }
+
+fun EmbedBuilder.createRulesEmbedDetailed(guild: Guild, rules: List<Rule>) {
+    title = "**__Rules__**"
+    thumbnail {
+        url = guild.getIconUrl(Image.Format.PNG) ?: ""
+    }
+    color = Color.MAGENTA
+
+    for (rule in rules) {
+        field {
+            value = "**[${rule.number}: ${rule.title}](${rule.link})**\n${rule.description}"
+            inline = false
+        }
+    }

--- a/src/main/kotlin/me/ddivad/judgebot/services/infractions/InfractionService.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/services/infractions/InfractionService.kt
@@ -32,6 +32,7 @@ class InfractionService(private val configuration: Configuration,
 
     private suspend fun applyPunishment(guild: Guild, target: Member, guildMember: GuildMember, infraction: Infraction) {
         when (infraction.punishment?.punishment) {
+            PunishmentType.NONE -> return
             PunishmentType.MUTE -> muteService.applyMute(target, infraction.punishment?.duration!!, infraction.reason)
             PunishmentType.BAN -> {
                 val clearTime = infraction.punishment!!.duration?.let { DateTime().millis.plus(it) }


### PR DESCRIPTION
# feat: add back long rules embed

- Add back the command and embed to list all rules and their description.
- Add a "None" type for punishments to avoid adding a punishment for a user at that step.
- Change default configuration of 0 point warn to punishment of "None".