### PR TITLE
fix: update more commands to use userarg

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -32,7 +32,7 @@
 | ------------ | ----------------------- | ------------------------------------------------- |
 | cleansenotes | LowerMemberArg          | Use this to delete (permanently) as user's notes. |
 | deleteNote   | LowerMemberArg, Integer | Use this to add a delete a note from a user.      |
-| note         | Member, Note Content    | Use this to add a note to a user.                 |
+| note         | User, Note Content      | Use this to add a note to a user.                 |
 
 ## Rules
 | Commands    | Arguments | Description                                       |
@@ -52,7 +52,7 @@
 | history, h   | User                                        | Use this to view a user's record.                          |
 | selfHistory  |                                             | View your infraction history (contents will be DM'd)       |
 | setBanReason | User, Text                                  | Set a ban reason for a banned user                         |
-| status, st   | Member                                      | Use this to view a user's status card.                     |
+| status, st   | User                                        | Use this to view a user's status card.                     |
 | unban        | User                                        | Unban a banned member from this guild.                     |
 | whatpfp      | User                                        | Perform a reverse image search of a User's profile picture |
 

--- a/src/main/kotlin/me/ddivad/judgebot/commands/NoteCommands.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/commands/NoteCommands.kt
@@ -8,13 +8,14 @@ import me.ddivad.judgebot.services.requiredPermissionLevel
 import me.jakejmattson.discordkt.api.arguments.EveryArg
 import me.jakejmattson.discordkt.api.arguments.IntegerArg
 import me.jakejmattson.discordkt.api.arguments.MemberArg
+import me.jakejmattson.discordkt.api.arguments.UserArg
 import me.jakejmattson.discordkt.api.dsl.commands
 
 fun noteCommands(databaseService: DatabaseService) = commands("Notes") {
     guildCommand("note") {
         description = "Use this to add a note to a user."
         requiredPermissionLevel = PermissionLevel.Moderator
-        execute(MemberArg, EveryArg("Note Content")) {
+        execute(UserArg, EveryArg("Note Content")) {
             val (target, note) = args
             val user = databaseService.users.getOrCreateUser(target, guild)
             databaseService.users.addNote(guild, user, note, author.id.value)

--- a/src/main/kotlin/me/ddivad/judgebot/commands/UserCommands.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/commands/UserCommands.kt
@@ -2,6 +2,7 @@ package me.ddivad.judgebot.commands
 
 import com.gitlab.kordlib.common.exception.RequestException
 import com.gitlab.kordlib.core.behavior.ban
+import com.gitlab.kordlib.core.entity.User
 import me.ddivad.judgebot.arguments.LowerMemberArg
 import me.ddivad.judgebot.dataclasses.Ban
 import me.ddivad.judgebot.dataclasses.Configuration
@@ -40,7 +41,7 @@ fun createUserCommands(databaseService: DatabaseService,
     guildCommand("status", "st") {
         description = "Use this to view a user's status card."
         requiredPermissionLevel = PermissionLevel.Moderator
-        execute(MemberArg) {
+        execute(UserArg) {
             val user = databaseService.users.getOrCreateUser(args.first, guild)
             databaseService.users.incrementUserHistory(user, guild)
             createStatusEmbed(args.first, user, guild, config)


### PR DESCRIPTION
# fix: update more commands to use userarg

Change some commands to use UserArg instead of LowerMember or MemberArg to deal with users that have left.

- Update Note to use UserArg.
- Update Status to use UserArg