### PR TITLE
fix: fix message delete embed when message length > 1024 characters

### DIFF
--- a/src/main/kotlin/me/ddivad/judgebot/embeds/InfractionEmbeds.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/embeds/InfractionEmbeds.kt
@@ -156,7 +156,10 @@ fun EmbedBuilder.createModeratorInfractionEmbed(guild: Guild, user: Member, infr
     }
 }
 
-fun EmbedBuilder.createMessageDeleteEmbed(guild: Guild, user: User, message: Message) {
+fun EmbedBuilder.createMessageDeleteEmbed(guild: Guild, message: Message) {
+    var messageContent = message.content.take(1010)
+    if (message.content.length > 1024) messageContent += " ..."
+
     title = "Message Deleted"
     thumbnail {
         url = guild.getIconUrl(Image.Format.PNG) ?: ""
@@ -166,7 +169,7 @@ fun EmbedBuilder.createMessageDeleteEmbed(guild: Guild, user: User, message: Mes
         Your ${if (message.attachments.isNotEmpty()) "image" else "message"} was deleted from ${message.channel.mention} 
         as it is against our server rules.
     """.trimIndent()
-    addField("Message", "```${message.content}```")
+    addField("Message", "```${messageContent}```")
     if (message.attachments.isNotEmpty()) {
         addField("Filename", "```${message.attachments.first().filename}```")
     }


### PR DESCRIPTION
# fix: fix message delete embed when message length > 1024 chars

- Update the message delete to truncate the message  to 1010 characters + "..." if it is greater than 1024 characters (max field size for an embed). 1010 was used, as 4 characters are needed for " ..." and 6 are needed to add the codeblock ("``` ```").
- Update listener to catch let the moderator know if the user has DM's disabled.