### PR TITLE
fix: user leaving guild with active mute didn't remove punishment

### DIFF
--- a/src/main/kotlin/me/ddivad/judgebot/commands/MuteCommands.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/commands/MuteCommands.kt
@@ -40,7 +40,7 @@ fun createMuteCommands(muteService: MuteService) = commands("Mute") {
                 return@execute
             }
 
-            muteService.removeMute(targetMember)
+            muteService.removeMute(guild, targetMember.asUser())
             respond("User ${args.first.username} has been unmuted")
         }
     }

--- a/src/main/kotlin/me/ddivad/judgebot/embeds/InfractionEmbeds.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/embeds/InfractionEmbeds.kt
@@ -113,7 +113,7 @@ fun EmbedBuilder.createMuteEmbed(guild: Guild, user: User, reason: String, lengt
     }
 }
 
-fun EmbedBuilder.createUnmuteEmbed(guild: Guild, user: Member) {
+fun EmbedBuilder.createUnmuteEmbed(guild: Guild, user: User) {
     color = Color.GREEN
     title = "Mute Removed"
     description = "${user.mention} you have been unmuted from **${guild.name}**."

--- a/src/main/kotlin/me/ddivad/judgebot/services/infractions/BadPfpService.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/services/infractions/BadPfpService.kt
@@ -54,7 +54,7 @@ class BadPfpService(private val muteService: MuteService,
             badPfpTracker[key]?.cancel()
             badPfpTracker.remove(key)
             loggingService.badPfpCancelled(guild, target)
-            muteService.removeMute(target)
+            muteService.removeMute(guild, target.asUser())
         }
     }
 }


### PR DESCRIPTION
# fix: user leaving guild with active mute didn't remove punishment

Fixed a case where a muted user that left wouldn't have the punishment removed, and an error would be thrown when trying to remove the role / DM them that infromation.