### PR TITLE
fix: unmute and ban commands not functioning correctly

### DIFF
--- a/src/main/kotlin/me/ddivad/judgebot/commands/MuteCommands.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/commands/MuteCommands.kt
@@ -35,13 +35,13 @@ fun createMuteCommands(muteService: MuteService) = commands("Mute") {
         requiredPermissionLevel = PermissionLevel.Moderator
         execute(LowerMemberArg) {
             val targetMember = args.first
-            if (muteService.checkRoleState(guild, targetMember, InfractionType.Mute) == RoleState.None) {
+            if (muteService.checkRoleState(guild, targetMember) == RoleState.None) {
                 respond("User ${targetMember.mention} isn't muted")
                 return@execute
             }
 
             muteService.removeMute(guild, targetMember.asUser())
-            respond("User ${args.first.username} has been unmuted")
+            respond("User ${args.first.mention} has been unmuted")
         }
     }
 
@@ -56,7 +56,7 @@ fun createMuteCommands(muteService: MuteService) = commands("Mute") {
                 respond("Unable to contact the target user. Infraction cancelled.")
                 return@execute
             }
-            if (muteService.checkRoleState(guild, targetMember, InfractionType.Mute) == RoleState.Tracked) {
+            if (muteService.checkRoleState(guild, targetMember) == RoleState.Tracked) {
                 respond("User ${targetMember.mention} is already muted")
                 return@execute
             }

--- a/src/main/kotlin/me/ddivad/judgebot/commands/UserCommands.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/commands/UserCommands.kt
@@ -6,6 +6,8 @@ import com.gitlab.kordlib.core.entity.User
 import me.ddivad.judgebot.arguments.LowerMemberArg
 import me.ddivad.judgebot.dataclasses.Ban
 import me.ddivad.judgebot.dataclasses.Configuration
+import me.ddivad.judgebot.dataclasses.InfractionType
+import me.ddivad.judgebot.dataclasses.Punishment
 import me.ddivad.judgebot.embeds.createHistoryEmbed
 import me.ddivad.judgebot.embeds.createSelfHistoryEmbed
 import me.ddivad.judgebot.embeds.createStatusEmbed
@@ -68,14 +70,10 @@ fun createUserCommands(databaseService: DatabaseService,
         requiredPermissionLevel = PermissionLevel.Staff
         execute(LowerMemberArg, IntegerArg("Delete message days").makeOptional(1), EveryArg) {
             val (target, deleteDays, reason) = args
-            guild.ban(target.id) {
-                this.reason = reason
-                this.deleteMessagesDays = deleteDays
-                val ban = Ban(target.id.value, reason, author.id.value)
-                databaseService.guilds.addBan(guild, target.id.value, ban).also {
-                    loggingService.userBanned(guild, target.asUser(), it)
-                    respond("User ${target.mention} banned")
-                }
+            val ban = Punishment(target.id.value, InfractionType.Ban , reason, author.id.value)
+            banService.banUser(target, guild, ban, deleteDays).also {
+                loggingService.userBanned(guild, target.asUser(), ban)
+                respond("User ${target.mention} banned")
             }
         }
     }

--- a/src/main/kotlin/me/ddivad/judgebot/listeners/RejoinMuteListener.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/listeners/RejoinMuteListener.kt
@@ -11,7 +11,7 @@ fun onMemberRejoinWithMute(muteService: MuteService, loggingService: LoggingServ
     on<MemberJoinEvent> {
         val member = this.member
         val guild = this.getGuild()
-        if (muteService.checkRoleState(guild, member, InfractionType.Mute) == RoleState.Tracked) {
+        if (muteService.checkRoleState(guild, member) == RoleState.Tracked) {
             muteService.handleRejoinMute(guild, member)
             loggingService.rejoinMute(guild, member.asUser(), RoleState.Tracked)
         }

--- a/src/main/kotlin/me/ddivad/judgebot/services/LoggingService.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/services/LoggingService.kt
@@ -34,7 +34,7 @@ class LoggingService(private val configuration: Configuration) {
     suspend fun channelOverrideAdded(guild: Guild, channel: TextChannel) =
             log(guild, "**Info ::** Channel overrides for muted role added to ${channel.name}")
 
-    suspend fun userBanned(guild: Guild, user: User, ban: Ban) {
+    suspend fun userBanned(guild: Guild, user: User, ban: Punishment) {
         val moderator = guild.kord.getUser(Snowflake(ban.moderator))
         log(guild, "**Info ::** User ${user.mention} :: ${user.tag} banned by ${moderator?.username} for reason: ${ban.reason}")
     }

--- a/src/main/kotlin/me/ddivad/judgebot/services/infractions/BanService.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/services/infractions/BanService.kt
@@ -21,9 +21,9 @@ class BanService(private val databaseService: DatabaseService,
     private val banTracker = hashMapOf<Int, Job>()
     private suspend fun toKey(member: Member): Pair<GuildID, UserId> = member.guild.id.value to member.asUser().id.value
 
-    suspend fun banUser(target: Member, guild: Guild, moderator: String, punishment: Punishment) {
+    suspend fun banUser(target: Member, guild: Guild, punishment: Punishment, deleteDays: Int = 1) {
         guild.ban(target.id) {
-            deleteMessagesDays = 1
+            deleteMessagesDays = deleteDays
             reason = punishment.reason
         }
         databaseService.guilds.addBan(guild, target.id.value, Ban(target.id.value, punishment.moderator, punishment.reason))

--- a/src/main/kotlin/me/ddivad/judgebot/services/infractions/InfractionService.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/services/infractions/InfractionService.kt
@@ -37,7 +37,7 @@ class InfractionService(private val configuration: Configuration,
             PunishmentType.BAN -> {
                 val clearTime = infraction.punishment!!.duration?.let { DateTime().millis.plus(it) }
                 val punishment = Punishment(target.id.value, InfractionType.Ban, infraction.reason, infraction.moderator, clearTime)
-                banService.banUser(target, guild, infraction.moderator, punishment)
+                banService.banUser(target, guild, punishment)
             }
         }
     }


### PR DESCRIPTION
# fix: unmute and ban commands not functioning correctly

- Fix unmute command failing if the mute was applied manually, or via another bot.
- Fix ban command failing.
- Update mute service functions to remove need for `Infraction Type`