### PR TITLE
fix: update join/leave listener logic

### DIFF
--- a/src/main/kotlin/me/ddivad/judgebot/listeners/JoinLeaveListener.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/listeners/JoinLeaveListener.kt
@@ -4,6 +4,7 @@ import com.gitlab.kordlib.core.event.guild.GuildCreateEvent
 import com.gitlab.kordlib.core.event.guild.MemberJoinEvent
 import com.gitlab.kordlib.core.event.guild.MemberLeaveEvent
 import com.gitlab.kordlib.gateway.RequestGuildMembers
+import kotlinx.coroutines.flow.toList
 import me.ddivad.judgebot.services.DatabaseService
 import me.ddivad.judgebot.services.LoggingService
 import me.jakejmattson.discordkt.api.dsl.listeners
@@ -15,13 +16,16 @@ fun onGuildMemberLeave(loggingService: LoggingService, databaseService: Database
     }
 
     on<MemberLeaveEvent> {
-        val userRecord = databaseService.users.getOrCreateUser(this.user.asUser(), this.guild.asGuild())
-        databaseService.users.addGuildLeave(userRecord, this.getGuild(), DateTime.now().millis)
+        databaseService.users.getUserOrNull(this.user.asUser(), this.guild.asGuild())?.let {
+            databaseService.users.addGuildLeave(it, guild.asGuild(), DateTime.now().millis)
+        }
     }
 
     on<MemberJoinEvent> {
-        databaseService.users.getUserOrNull(this.member, this.guild.asGuild())?.let {
-            databaseService.users.addGuildJoin(guild.asGuild(), it, this.member.joinedAt.toEpochMilli())
+        databaseService.users.getUserOrNull(this.member.asUser(), this.guild.asGuild())?.let {
+            databaseService.users.addGuildJoin(this.getGuild(), it, this.member.joinedAt.toEpochMilli())
+            return@on
         }
+        databaseService.users.getOrCreateUser(this.member.asUser(), this.getGuild())
     }
 }

--- a/src/main/kotlin/me/ddivad/judgebot/listeners/JoinLeaveListener.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/listeners/JoinLeaveListener.kt
@@ -4,7 +4,10 @@ import com.gitlab.kordlib.core.event.guild.GuildCreateEvent
 import com.gitlab.kordlib.core.event.guild.MemberJoinEvent
 import com.gitlab.kordlib.core.event.guild.MemberLeaveEvent
 import com.gitlab.kordlib.gateway.RequestGuildMembers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
 import me.ddivad.judgebot.services.DatabaseService
 import me.ddivad.judgebot.services.LoggingService
 import me.jakejmattson.discordkt.api.dsl.listeners
@@ -22,10 +25,16 @@ fun onGuildMemberLeave(loggingService: LoggingService, databaseService: Database
     }
 
     on<MemberJoinEvent> {
-        databaseService.users.getUserOrNull(this.member.asUser(), this.guild.asGuild())?.let {
-            databaseService.users.addGuildJoin(this.getGuild(), it, this.member.joinedAt.toEpochMilli())
+        val user = this.member.asUser()
+        val guild = this.getGuild()
+        databaseService.users.getUserOrNull(user, guild)?.let {
+            databaseService.users.addGuildJoin(guild, it, this.member.joinedAt.toEpochMilli())
             return@on
         }
-        databaseService.users.getOrCreateUser(this.member.asUser(), this.getGuild())
+        // Add delay before creating user in case they are banned (raid, etc...)
+        GlobalScope.launch {
+            delay(1000 * 60 * 5)
+            databaseService.users.getOrCreateUser(member, guild)
+        }
     }
 }


### PR DESCRIPTION
# fix: update join/leave listener logic

Update join / leave listener logic:

- If user joins and isn't in the db -> create them.
- If user joins and has a record -> add a join date.
- If user leaves and has no record -> do nothing.
- If user leaves and has a record -> add leave date.