### PR TITLE
feat: simplify strike conversation

### DIFF
--- a/src/main/kotlin/me/ddivad/judgebot/commands/InfractionCommands.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/commands/InfractionCommands.kt
@@ -16,7 +16,8 @@ import me.jakejmattson.discordkt.api.arguments.EveryArg
 import me.jakejmattson.discordkt.api.arguments.IntegerArg
 import me.jakejmattson.discordkt.api.dsl.commands
 
-fun createInfractonCommands(databaseService: DatabaseService,
+@Suppress("unused")
+fun createInfractionCommands(databaseService: DatabaseService,
                             config: Configuration,
                             infractionService: InfractionService,
                             badPfpService: BadPfpService) = commands("Infraction") {

--- a/src/main/kotlin/me/ddivad/judgebot/commands/MuteCommands.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/commands/MuteCommands.kt
@@ -2,7 +2,6 @@ package me.ddivad.judgebot.commands
 
 import com.gitlab.kordlib.common.exception.RequestException
 import me.ddivad.judgebot.arguments.LowerMemberArg
-import me.ddivad.judgebot.dataclasses.InfractionType
 import me.ddivad.judgebot.extensions.testDmStatus
 import me.ddivad.judgebot.services.*
 import me.ddivad.judgebot.services.infractions.MuteService
@@ -13,6 +12,7 @@ import me.jakejmattson.discordkt.api.arguments.TimeArg
 import me.jakejmattson.discordkt.api.dsl.commands
 import kotlin.math.roundToLong
 
+@Suppress("unused")
 fun createMuteCommands(muteService: MuteService) = commands("Mute") {
     guildCommand("mute") {
         description = "Mute a user for a specified time."

--- a/src/main/kotlin/me/ddivad/judgebot/commands/NoteCommands.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/commands/NoteCommands.kt
@@ -1,16 +1,15 @@
 package me.ddivad.judgebot.commands
 
 import me.ddivad.judgebot.arguments.LowerMemberArg
-import me.ddivad.judgebot.dataclasses.Configuration
 import me.ddivad.judgebot.services.DatabaseService
 import me.ddivad.judgebot.services.PermissionLevel
 import me.ddivad.judgebot.services.requiredPermissionLevel
 import me.jakejmattson.discordkt.api.arguments.EveryArg
 import me.jakejmattson.discordkt.api.arguments.IntegerArg
-import me.jakejmattson.discordkt.api.arguments.MemberArg
 import me.jakejmattson.discordkt.api.arguments.UserArg
 import me.jakejmattson.discordkt.api.dsl.commands
 
+@Suppress("unused")
 fun noteCommands(databaseService: DatabaseService) = commands("Notes") {
     guildCommand("note") {
         description = "Use this to add a note to a user."

--- a/src/main/kotlin/me/ddivad/judgebot/commands/RuleCommands.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/commands/RuleCommands.kt
@@ -6,7 +6,6 @@ import me.ddivad.judgebot.conversations.rules.ArchiveRuleConversation
 import me.ddivad.judgebot.conversations.rules.EditRuleConversation
 import me.ddivad.judgebot.dataclasses.Configuration
 import me.ddivad.judgebot.embeds.createRuleEmbed
-import me.ddivad.judgebot.embeds.createRuleEmbedForStrike
 import me.ddivad.judgebot.embeds.createRulesEmbed
 import me.ddivad.judgebot.embeds.createRulesEmbedDetailed
 import me.ddivad.judgebot.services.DatabaseService
@@ -14,6 +13,7 @@ import me.ddivad.judgebot.services.PermissionLevel
 import me.ddivad.judgebot.services.requiredPermissionLevel
 import me.jakejmattson.discordkt.api.dsl.commands
 
+@Suppress("unused")
 fun ruleCommands(configuration: Configuration,
                  databaseService: DatabaseService) = commands("Rules") {
 
@@ -62,7 +62,7 @@ fun ruleCommands(configuration: Configuration,
         requiredPermissionLevel = PermissionLevel.Staff
         execute {
             respond {
-                createRulesEmbedDetailed(guild, databaseService.guilds.getRules(guild)!!)
+                createRulesEmbedDetailed(guild, databaseService.guilds.getRules(guild))
             }
         }
     }

--- a/src/main/kotlin/me/ddivad/judgebot/commands/UserCommands.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/commands/UserCommands.kt
@@ -1,8 +1,5 @@
 package me.ddivad.judgebot.commands
 
-import com.gitlab.kordlib.common.exception.RequestException
-import com.gitlab.kordlib.core.behavior.ban
-import com.gitlab.kordlib.core.entity.User
 import me.ddivad.judgebot.arguments.LowerMemberArg
 import me.ddivad.judgebot.dataclasses.*
 import me.ddivad.judgebot.embeds.createHistoryEmbed
@@ -16,12 +13,12 @@ import me.ddivad.judgebot.services.infractions.BanService
 import me.ddivad.judgebot.services.requiredPermissionLevel
 import me.jakejmattson.discordkt.api.arguments.EveryArg
 import me.jakejmattson.discordkt.api.arguments.IntegerArg
-import me.jakejmattson.discordkt.api.arguments.MemberArg
 import me.jakejmattson.discordkt.api.arguments.UserArg
 import me.jakejmattson.discordkt.api.dsl.commands
 import me.jakejmattson.discordkt.api.extensions.sendPrivateMessage
 import java.awt.Color
 
+@Suppress("unused")
 fun createUserCommands(databaseService: DatabaseService,
                        config: Configuration,
                        loggingService: LoggingService,

--- a/src/main/kotlin/me/ddivad/judgebot/conversations/StrikeConversation.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/conversations/StrikeConversation.kt
@@ -2,17 +2,13 @@ package me.ddivad.judgebot.conversations
 
 import com.gitlab.kordlib.core.entity.Guild
 import com.gitlab.kordlib.core.entity.Member
-import me.ddivad.judgebot.arguments.RuleArg
 import me.ddivad.judgebot.dataclasses.*
 import me.ddivad.judgebot.embeds.createHistoryEmbed
 import me.ddivad.judgebot.embeds.createRuleEmbedForStrike
 import me.ddivad.judgebot.services.DatabaseService
 import me.ddivad.judgebot.services.infractions.InfractionService
-import me.ddivad.judgebot.util.timeToString
-import me.jakejmattson.discordkt.api.arguments.BooleanArg
-import me.jakejmattson.discordkt.api.dsl.Conversation
+import me.jakejmattson.discordkt.api.arguments.IntegerArg
 import me.jakejmattson.discordkt.api.dsl.conversation
-import me.jakejmattson.discordkt.api.extensions.sendPrivateMessage
 
 class StrikeConversation(private val databaseService: DatabaseService,
                          private val configuration: Configuration,
@@ -21,14 +17,13 @@ class StrikeConversation(private val databaseService: DatabaseService,
         val guildConfiguration = configuration[guild.id.longValue] ?: return@conversation
         val user = databaseService.users.getOrCreateUser(targetUser, guild)
         val points = weight * guildConfiguration.infractionConfiguration.strikePoints
-        val addRule = promptMessage(BooleanArg("Add Rule", "y", "n"), "Add rule? (y/n)")
-        val rule = if (addRule) {
-            val rules = databaseService.guilds.getRules(guild)
+        val rules = databaseService.guilds.getRules(guild)
+        val ruleId = if (rules.isNotEmpty()) {
             respond { createRuleEmbedForStrike(guild, rules) }
-            promptMessage(RuleArg, "Enter rule number: ").number
+            val rule = promptMessage(IntegerArg, "Enter `0` for no rule, or rule id to add a rule:")
+            if (rule > 0) rule else null
         } else null
-        val infraction = Infraction(this.user.id.value, infractionReason, InfractionType.Strike, points, rule)
-
+        val infraction = Infraction(this.user.id.value, infractionReason, InfractionType.Strike, points, ruleId)
         infractionService.infract(targetUser, guild, user, infraction)
         respondMenu { createHistoryEmbed(targetUser, user, guild, configuration, databaseService) }
     }

--- a/src/main/kotlin/me/ddivad/judgebot/conversations/rules/AddRuleConversation.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/conversations/rules/AddRuleConversation.kt
@@ -14,7 +14,7 @@ class AddRuleConversation(private val configuration: Configuration,
                           private val databaseService: DatabaseService) {
     fun createAddRuleConversation(guild: Guild) = conversation("cancel") {
         val rules = databaseService.guilds.getRules(guild)
-        val nextId = rules?.size?.plus(1)!!
+        val nextId = rules.size.plus(1)
 
         val ruleName = promptMessage(EveryArg, "Please enter rule name:")
         val ruleText = promptMessage(EveryArg, "Please enter rule text")

--- a/src/main/kotlin/me/ddivad/judgebot/conversations/rules/EditRuleConversation.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/conversations/rules/EditRuleConversation.kt
@@ -16,7 +16,7 @@ class EditRuleConversation(private val configuration: Configuration,
     fun createAddRuleConversation(guild: Guild) = conversation("cancel") {
         val rules = databaseService.guilds.getRules(guild)
         val ruleNumberToUpdate = promptMessage(IntegerArg, "Which rule would you like to update?")
-        val ruleToUpdate = rules?.find { it.number == ruleNumberToUpdate } ?: return@conversation
+        val ruleToUpdate = rules.find { it.number == ruleNumberToUpdate } ?: return@conversation
         respond("Current Rule:")
         respond {
             createRuleEmbed(guild, ruleToUpdate)
@@ -28,10 +28,10 @@ class EditRuleConversation(private val configuration: Configuration,
             updateNumber -> promptUntil(
                     argumentType = IntegerArg,
                     prompt = "Please enter rule number:",
-                    isValid = { number -> !rules?.any { it.number == number } },
+                    isValid = { number -> !rules.any { it.number == number } },
                     error = "Rule with that number already exists"
             )
-            else -> ruleToUpdate!!.number
+            else -> ruleToUpdate.number
         }
         val updateName = promptMessage(BooleanArg(truthValue = "y", falseValue = "n"),
                 "Update Rule name? (Y/N)")
@@ -40,7 +40,7 @@ class EditRuleConversation(private val configuration: Configuration,
                     EveryArg,
                     "Please enter rule name:",
                     "Rule with that name already exists",
-                    isValid = { name -> !rules?.any { it.title == name } }
+                    isValid = { name -> !rules.any { it.title == name } }
             )
             else -> ruleToUpdate.title
         }

--- a/src/main/kotlin/me/ddivad/judgebot/dataclasses/GuildInformation.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/dataclasses/GuildInformation.kt
@@ -12,10 +12,6 @@ data class GuildInformation(
         return this
     }
 
-    fun getRuleById(ruleNumber: Int): Rule? {
-        return this.rules.firstOrNull { it.number == ruleNumber }
-    }
-
     fun archiveRule(ruleNumber: Int): GuildInformation {
         this.rules.find { it.number == ruleNumber }!!.archived = true
         return this

--- a/src/main/kotlin/me/ddivad/judgebot/embeds/RuleEmbeds.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/embeds/RuleEmbeds.kt
@@ -6,8 +6,6 @@ import me.ddivad.judgebot.dataclasses.Rule
 import me.jakejmattson.discordkt.api.extensions.addField
 import java.awt.Color
 import com.gitlab.kordlib.rest.Image
-import me.ddivad.judgebot.arguments.validConfigParameters
-import me.jakejmattson.discordkt.api.dsl.MenuBuilder
 
 fun EmbedBuilder.createRuleEmbed(guild: Guild, rule: Rule) {
     title = "__${rule.number}: ${rule.title}__"
@@ -43,7 +41,7 @@ fun EmbedBuilder.createRulesEmbed(guild: Guild, rules: List<Rule>) {
     }
 }
 
-suspend fun EmbedBuilder.createRuleEmbedForStrike(guild: Guild, rules: List<Rule>) {
+fun EmbedBuilder.createRuleEmbedForStrike(guild: Guild, rules: List<Rule>) {
     title = "**__Available Rules__**"
     color = Color.MAGENTA
     description = ""

--- a/src/main/kotlin/me/ddivad/judgebot/listeners/JoinLeaveListener.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/listeners/JoinLeaveListener.kt
@@ -6,13 +6,13 @@ import com.gitlab.kordlib.core.event.guild.MemberLeaveEvent
 import com.gitlab.kordlib.gateway.RequestGuildMembers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import me.ddivad.judgebot.services.DatabaseService
 import me.ddivad.judgebot.services.LoggingService
 import me.jakejmattson.discordkt.api.dsl.listeners
 import org.joda.time.DateTime
 
+@Suppress("unused")
 fun onGuildMemberLeave(loggingService: LoggingService, databaseService: DatabaseService) = listeners {
     on<GuildCreateEvent> {
         gateway.send(RequestGuildMembers(guildId = listOf(guild.id.value)))

--- a/src/main/kotlin/me/ddivad/judgebot/listeners/MemberReactionListeners.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/listeners/MemberReactionListeners.kt
@@ -8,6 +8,7 @@ import me.ddivad.judgebot.extensions.jumpLink
 import me.jakejmattson.discordkt.api.dsl.listeners
 import me.jakejmattson.discordkt.api.extensions.toSnowflake
 
+@Suppress("unused")
 fun onMemberReactionAdd(configuration: Configuration) = listeners {
     on<ReactionAddEvent> {
         val guild = guild?.asGuildOrNull() ?: return@on

--- a/src/main/kotlin/me/ddivad/judgebot/listeners/NewChannelOverrideListener.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/listeners/NewChannelOverrideListener.kt
@@ -9,6 +9,7 @@ import me.ddivad.judgebot.services.LoggingService
 import me.jakejmattson.discordkt.api.dsl.listeners
 import me.jakejmattson.discordkt.api.extensions.toSnowflake
 
+@Suppress("unused")
 fun onChannelCreated(configuration: Configuration, loggingService: LoggingService) = listeners {
     on<TextChannelCreateEvent> {
         val channel = this.channel

--- a/src/main/kotlin/me/ddivad/judgebot/listeners/RejoinMuteListener.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/listeners/RejoinMuteListener.kt
@@ -7,6 +7,7 @@ import me.ddivad.judgebot.services.infractions.MuteService
 import me.ddivad.judgebot.services.infractions.RoleState
 import me.jakejmattson.discordkt.api.dsl.listeners
 
+@Suppress("unused")
 fun onMemberRejoinWithMute(muteService: MuteService, loggingService: LoggingService) = listeners {
     on<MemberJoinEvent> {
         val member = this.member

--- a/src/main/kotlin/me/ddivad/judgebot/listeners/StaffReactionListeners.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/listeners/StaffReactionListeners.kt
@@ -13,6 +13,7 @@ import me.ddivad.judgebot.services.infractions.MuteService
 import me.jakejmattson.discordkt.api.dsl.listeners
 import me.jakejmattson.discordkt.api.extensions.sendPrivateMessage
 
+@Suppress("unused")
 fun onStaffReactionAdd(muteService: MuteService,
                        databaseService: DatabaseService,
                        permissionsService: PermissionsService,

--- a/src/main/kotlin/me/ddivad/judgebot/services/PermissionsService.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/services/PermissionsService.kt
@@ -4,8 +4,6 @@ import com.gitlab.kordlib.core.any
 import com.gitlab.kordlib.core.entity.Guild
 import com.gitlab.kordlib.core.entity.Member
 import com.gitlab.kordlib.core.entity.User
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.first
 import me.ddivad.judgebot.dataclasses.Configuration
 import me.jakejmattson.discordkt.api.annotations.Service
 import me.jakejmattson.discordkt.api.dsl.Command

--- a/src/main/kotlin/me/ddivad/judgebot/services/database/GuildOperations.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/services/database/GuildOperations.kt
@@ -11,7 +11,7 @@ import org.litote.kmongo.eq
 // Note: RunBlocking is needed for DB operations in this service, as they are used in a conversation (which does not support "suspend" functions)
 
 @Service
-class GuildOperations(private val connection: ConnectionService) {
+class GuildOperations(connection: ConnectionService) {
     private val guildCollection = connection.db.getCollection<GuildInformation>("Guilds")
 
     suspend fun setupGuild(guild: Guild): GuildInformation {

--- a/src/main/kotlin/me/ddivad/judgebot/services/database/UserOperations.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/services/database/UserOperations.kt
@@ -11,7 +11,7 @@ import me.jakejmattson.discordkt.api.annotations.Service
 import org.litote.kmongo.eq
 
 @Service
-class UserOperations(private val connection: ConnectionService, private val configuration: Configuration) {
+class UserOperations(connection: ConnectionService, private val configuration: Configuration) {
     private val userCollection = connection.db.getCollection<GuildMember>("Users")
 
     suspend fun getOrCreateUser(target: User, guild: Guild): GuildMember {


### PR DESCRIPTION
# feat: simplify strike conversation

Simplify strike converation. A Strike will show all rules now, and let the user enter either `0` or the rule id when issuing a strike. 0 will add a strike without a rule reference, entering the ID will add a rule as before.

Also, some gradle warnings were removed. 