### PR TITLE
feat: initialise existing bans upon bot restart

### DIFF
--- a/src/main/kotlin/me/ddivad/judgebot/Main.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/Main.kt
@@ -4,8 +4,10 @@ import com.gitlab.kordlib.gateway.Intent
 import com.gitlab.kordlib.gateway.PrivilegedIntent
 import me.ddivad.judgebot.dataclasses.Configuration
 import me.ddivad.judgebot.services.BotStatsService
+import me.ddivad.judgebot.services.LoggingService
 import me.ddivad.judgebot.services.infractions.MuteService
 import me.ddivad.judgebot.services.PermissionsService
+import me.ddivad.judgebot.services.infractions.BanService
 import me.ddivad.judgebot.services.requiredPermissionLevel
 import me.jakejmattson.discordkt.api.dsl.bot
 import me.jakejmattson.discordkt.api.extensions.addInlineField
@@ -81,8 +83,9 @@ suspend fun main(args: Array<String>) {
         }
 
         onStart {
-            val muteService = this.getInjectionObjects(MuteService::class)
+            val (muteService, banService, loggingService) = this.getInjectionObjects(MuteService::class, BanService::class, LoggingService::class)
             muteService.initGuilds()
+            banService.initialiseBanTimers()
         }
 
         intents {

--- a/src/main/kotlin/me/ddivad/judgebot/services/LoggingService.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/services/LoggingService.kt
@@ -62,8 +62,11 @@ class LoggingService(private val configuration: Configuration) {
     suspend fun badPfpBan(guild: Guild, user: Member) =
             log(guild, "**Info ::** User ${user.mention} banned for not changing their avatar")
 
-    suspend fun muteSetup(guild: Guild, role: Role) =
-            log(guild, "**Info ::** Adding muted role overrides for ${role.mention} :: ${role.id.value}")
+    suspend fun initialiseMutes(guild: Guild, role: Role) =
+            log(guild, "**Info ::** Existing mute timers initialized using ${role.mention} :: ${role.id}")
+
+    suspend fun initialiseBans(guild: Guild) =
+            log(guild, "**Info ::** Existing ban timers initialized.")
 
     private suspend fun log(guild: Guild, message: String) = getLoggingChannel(guild)?.createMessage(message)
 

--- a/src/main/kotlin/me/ddivad/judgebot/services/infractions/BanService.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/services/infractions/BanService.kt
@@ -8,18 +8,21 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import me.ddivad.judgebot.dataclasses.Ban
-import me.ddivad.judgebot.dataclasses.InfractionType
-import me.ddivad.judgebot.dataclasses.Punishment
+import me.ddivad.judgebot.dataclasses.*
 import me.ddivad.judgebot.services.DatabaseService
 import me.ddivad.judgebot.services.LoggingService
+import me.jakejmattson.discordkt.api.Discord
 import me.jakejmattson.discordkt.api.annotations.Service
+import me.jakejmattson.discordkt.api.extensions.toSnowflake
+import org.joda.time.DateTime
 
 @Service
 class BanService(private val databaseService: DatabaseService,
-                 private val loggingService: LoggingService) {
-    private val banTracker = hashMapOf<Int, Job>()
-    private suspend fun toKey(member: Member): Pair<GuildID, UserId> = member.guild.id.value to member.asUser().id.value
+                 private val loggingService: LoggingService,
+                 private val configuration: Configuration,
+                 private val discord: Discord) {
+    private val banTracker = hashMapOf<Pair<UserId, GuildID>, Job>()
+    private fun toKey(user: User, guild: Guild): Pair<GuildID, UserId> = user.id.value to guild.id.value
 
     suspend fun banUser(target: Member, guild: Guild, punishment: Punishment, deleteDays: Int = 1) {
         guild.ban(target.id) {
@@ -29,7 +32,8 @@ class BanService(private val databaseService: DatabaseService,
         databaseService.guilds.addBan(guild, Ban(target.id.value, punishment.moderator, punishment.reason))
         if (punishment.clearTime != null) {
             databaseService.guilds.addPunishment(guild.asGuild(), punishment)
-            banTracker[punishment.id] = GlobalScope.launch {
+            val key = toKey(target.asUser(), guild)
+            banTracker[key] = GlobalScope.launch {
                 delay(punishment.clearTime)
                 guild.unban(target.id)
             }
@@ -38,13 +42,33 @@ class BanService(private val databaseService: DatabaseService,
     }
 
     suspend fun unbanUser(guild: Guild, user: User) {
+        val key = toKey(user, guild)
         if (databaseService.guilds.getPunishmentsForUser(guild, user).any { it.type == InfractionType.Ban }) {
-            val punishment = databaseService.guilds.getPunishmentByType(guild, user.id.value, InfractionType.Ban).first()
             databaseService.guilds.removePunishment(guild, user.id.value, InfractionType.Ban)
-            banTracker[punishment.id]?.cancel()
+            banTracker[key]?.cancel()
         }
         guild.unban(user.id)
         databaseService.guilds.removeBan(guild, user.id.value)
         loggingService.userUnbanned(guild, user)
+    }
+
+    suspend fun initialiseBanTimers() {
+        configuration.guildConfigurations.forEach { config ->
+            val guild = config.value.id.toSnowflake().let { discord.api.getGuild(it) } ?: return@forEach
+            databaseService.guilds.getPunishmentsForGuild(guild, InfractionType.Ban).forEach() {
+                if (it.clearTime != null) {
+                    val difference = it.clearTime - DateTime.now().millis
+                    guild.kord.getUser(it.userId.toSnowflake())?.let { user ->
+                        val key = toKey(user, guild)
+                        banTracker[key] = GlobalScope.launch {
+                            delay(difference)
+                            guild.unban(user.id)
+                        }
+                    }
+                    loggingService.initialiseBans(guild)
+                }
+            }
+        }
+
     }
 }

--- a/src/main/kotlin/me/ddivad/judgebot/services/infractions/InfractionService.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/services/infractions/InfractionService.kt
@@ -2,6 +2,7 @@ package me.ddivad.judgebot.services.infractions
 
 import com.gitlab.kordlib.core.entity.Guild
 import com.gitlab.kordlib.core.entity.Member
+import kotlinx.coroutines.Job
 import me.ddivad.judgebot.dataclasses.*
 import me.ddivad.judgebot.embeds.createInfractionEmbed
 import me.ddivad.judgebot.services.DatabaseService
@@ -16,6 +17,10 @@ class InfractionService(private val configuration: Configuration,
                         private val loggingService: LoggingService,
                         private val banService: BanService,
                         private val muteService: MuteService) {
+
+    private val punishmentTimerMap = hashMapOf<Pair<Int, GuildID>, Job>()
+    private fun toKey(punishment: Punishment, guild: Guild) = punishment.id to guild.id.value
+
     suspend fun infract(target: Member, guild: Guild, userRecord: GuildMember, infraction: Infraction): Infraction {
         var rule: Rule? = null
         if (infraction.ruleNumber != null) {


### PR DESCRIPTION
# feat: initialise existing bans upon bot restart

- Initialise ban timers upon bot restart.
- Update logging upon bot restart for adding existing ban & mute timers.
- Update messaging when DMs are disabled.
- Add error if user tries to enter too large a strike weight.