### PR TITLE
fix: staff reaction listeners check for staff level

### DIFF
--- a/src/main/kotlin/me/ddivad/judgebot/arguments/LowerMemberArg.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/arguments/LowerMemberArg.kt
@@ -29,6 +29,6 @@ open class LowerMemberArg(override val name: String = "LowerMemberArg") : Argume
     override fun formatData(data: Member) = "@${data.tag}"
 }
 
-private suspend fun Member.isHigherRankedThan(permissions: PermissionsService, targetMember: Member) =
+suspend fun Member.isHigherRankedThan(permissions: PermissionsService, targetMember: Member) =
         permissions.getPermissionRank(this) < permissions.getPermissionRank(targetMember)
 

--- a/src/main/kotlin/me/ddivad/judgebot/listeners/MemberReactionListeners.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/listeners/MemberReactionListeners.kt
@@ -3,6 +3,8 @@ package me.ddivad.judgebot.listeners
 import com.gitlab.kordlib.core.behavior.getChannelOf
 import com.gitlab.kordlib.core.entity.channel.TextChannel
 import com.gitlab.kordlib.core.event.message.ReactionAddEvent
+import com.gitlab.kordlib.kordx.emoji.Emojis
+import com.gitlab.kordlib.kordx.emoji.addReaction
 import me.ddivad.judgebot.dataclasses.Configuration
 import me.ddivad.judgebot.extensions.jumpLink
 import me.jakejmattson.discordkt.api.dsl.listeners
@@ -15,11 +17,11 @@ fun onMemberReactionAdd(configuration: Configuration) = listeners {
         val guildConfiguration = configuration[guild.asGuild().id.longValue]
         if (!guildConfiguration?.reactions!!.enabled) return@on
 
-        if(this.emoji.name == guildConfiguration.reactions.flagMessageReaction) {
+        if (this.emoji.name == guildConfiguration.reactions.flagMessageReaction) {
             message.deleteReaction(this.emoji)
             guild.asGuild().getChannelOf<TextChannel>(guildConfiguration.loggingConfiguration.alertChannel.toSnowflake())
                     .asChannel().createMessage("User ${user.mention} flagged the message: " +
-                            "${this.message.asMessage().jumpLink(guild.id.value)} in: ${this.channel.mention}")
+                            "${this.message.asMessage().jumpLink(guild.id.value)} in: ${this.channel.mention}").addReaction(Emojis.whiteCheckMark)
         }
     }
 }

--- a/src/main/kotlin/me/ddivad/judgebot/listeners/MemberReactionListeners.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/listeners/MemberReactionListeners.kt
@@ -17,11 +17,13 @@ fun onMemberReactionAdd(configuration: Configuration) = listeners {
         val guildConfiguration = configuration[guild.asGuild().id.longValue]
         if (!guildConfiguration?.reactions!!.enabled) return@on
 
-        if (this.emoji.name == guildConfiguration.reactions.flagMessageReaction) {
-            message.deleteReaction(this.emoji)
-            guild.asGuild().getChannelOf<TextChannel>(guildConfiguration.loggingConfiguration.alertChannel.toSnowflake())
-                    .asChannel().createMessage("User ${user.mention} flagged the message: " +
-                            "${this.message.asMessage().jumpLink(guild.id.value)} in: ${this.channel.mention}").addReaction(Emojis.whiteCheckMark)
+        when (this.emoji.name) {
+            guildConfiguration.reactions.flagMessageReaction -> {
+                message.deleteReaction(this.emoji)
+                guild.asGuild().getChannelOf<TextChannel>(guildConfiguration.loggingConfiguration.alertChannel.toSnowflake()).asChannel()
+                        .createMessage("User ${user.mention} flagged the message: ${this.message.asMessage().jumpLink(guild.id.value)} in: ${this.channel.mention}")
+                        .addReaction(Emojis.whiteCheckMark)
+            }
         }
     }
 }

--- a/src/main/kotlin/me/ddivad/judgebot/listeners/StaffReactionListeners.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/listeners/StaffReactionListeners.kt
@@ -2,6 +2,7 @@ package me.ddivad.judgebot.listeners
 
 import com.gitlab.kordlib.common.exception.RequestException
 import com.gitlab.kordlib.core.event.message.ReactionAddEvent
+import me.ddivad.judgebot.arguments.isHigherRankedThan
 import me.ddivad.judgebot.dataclasses.Configuration
 import me.ddivad.judgebot.embeds.createMessageDeleteEmbed
 import me.ddivad.judgebot.embeds.createSelfHistoryEmbed
@@ -23,9 +24,8 @@ fun onStaffReactionAdd(muteService: MuteService,
         if (!guildConfiguration?.reactions!!.enabled) return@on
 
         user.asMemberOrNull(guild.id)?.let {
-            if (permissionsService.hasPermission(it, PermissionLevel.Moderator)) {
-                val messageAuthor = message.asMessage().author ?: return@on
-
+            val messageAuthor = message.asMessage().author?.asMemberOrNull(guild.id) ?: return@on
+            if (permissionsService.hasPermission(it, PermissionLevel.Moderator) && !it.isHigherRankedThan(permissionsService, messageAuthor)) {
                 when (this.emoji.name) {
                     guildConfiguration.reactions.gagReaction -> {
                         message.deleteReaction(this.emoji)


### PR DESCRIPTION
# fix: staff reaction listeners check for staff level

Update reaction listeners.

- Fix issue where staff could gag staff members of a higher level.
- Add white check mark reaction to Alerts by default.
- Cleanup reaction handling code.