### PR TITLE
fix: rule headings missing on mobile when no link added

### DIFF
--- a/src/main/kotlin/me/ddivad/judgebot/Main.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/Main.kt
@@ -58,7 +58,7 @@ suspend fun main(args: Array<String>) {
             field {
                 name = "Build Info"
                 value = "```" +
-                        "Version:   1.3.2\n" +
+                        "Version:   1.3.3\n" +
                         "DiscordKt: ${versions.library}\n" +
                         "Kotlin:    $kotlinVersion" +
                         "```"

--- a/src/main/kotlin/me/ddivad/judgebot/embeds/RuleEmbeds.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/embeds/RuleEmbeds.kt
@@ -64,7 +64,8 @@ fun EmbedBuilder.createRulesEmbedDetailed(guild: Guild, rules: List<Rule>) {
 
     for (rule in rules) {
         field {
-            value = "**__[${rule.number}. ${rule.title}](${rule.link})__**\n${rule.description}"
+            value = if (rule.link != "") "**__[${rule.number}. ${rule.title}](${rule.link})__**\n${rule.description}"
+            else "**__${rule.number}. ${rule.title}__**\n${rule.description}"
             inline = false
         }
     }


### PR DESCRIPTION
# fix: rule headings missing on mobile when no link added

Update link headings to remove link markdown if no link present. This worked fine on desktop before this change, but on mobile it seems this is handled differently and caused issues.