### PR TITLE
feat: miscellaneous updates

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -41,14 +41,14 @@
 | note         | User, Note Content      | Use this to add a note to a user.                 |
 
 ## Rules
-| Commands    | Arguments | Description                                       |
-| ----------- | --------- | ------------------------------------------------- |
-| addRule     |           | Add a rule to this guild.                         |
-| archiveRule |           | Archive a rule in this guild.                     |
-| editRule    |           | Edit a rule in this guild.                        |
-| longRules   |           | List the rules (with descriptions) of this guild. |
-| rule        | Rule      | List a rule from this guild.                      |
-| rules       |           | List the rules of this guild.                     |
+| Commands    | Arguments | Description                                                                                       |
+| ----------- | --------- | ------------------------------------------------------------------------------------------------- |
+| addRule     |           | Add a rule to this guild.                                                                         |
+| archiveRule |           | Archive a rule in this guild.                                                                     |
+| editRule    |           | Edit a rule in this guild.                                                                        |
+| longRules   | (Message) | List the rules (with descriptions) of this guild. Pass a message ID to edit existing rules embed. |
+| rule        | Rule      | List a rule from this guild.                                                                      |
+| rules       | (Message) | List the rules of this guild. Pass a message ID to edit existing rules embed.                     |
 
 ## User
 | Commands     | Arguments                                   | Description                                                |

--- a/src/main/kotlin/me/ddivad/judgebot/commands/InfractionCommands.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/commands/InfractionCommands.kt
@@ -2,7 +2,7 @@ package me.ddivad.judgebot.commands
 
 import com.gitlab.kordlib.common.exception.RequestException
 import me.ddivad.judgebot.arguments.LowerMemberArg
-import me.ddivad.judgebot.conversations.StrikeConversation
+import me.ddivad.judgebot.conversations.InfractionConversation
 import me.ddivad.judgebot.dataclasses.Configuration
 import me.ddivad.judgebot.dataclasses.Infraction
 import me.ddivad.judgebot.dataclasses.InfractionType
@@ -38,8 +38,8 @@ fun createInfractionCommands(databaseService: DatabaseService,
                 respond("Target user has DM's disabled. Infraction cancelled.")
                 return@execute
             }
-            StrikeConversation(databaseService, config, infractionService)
-                    .createStrikeConversation(guild, targetMember, weight, reason)
+            InfractionConversation(databaseService, config, infractionService)
+                    .createInfractionConversation(guild, targetMember, weight, reason, InfractionType.Strike)
                     .startPublicly(discord, author, channel)
         }
     }
@@ -55,13 +55,9 @@ fun createInfractionCommands(databaseService: DatabaseService,
                 respond("Target user has DM's disabled. Infraction cancelled.")
                 return@execute
             }
-            val guildConfiguration = config[guild.id.longValue] ?: return@execute
-            val user = databaseService.users.getOrCreateUser(targetMember, guild)
-            val infraction = Infraction(this.author.id.value, reason, InfractionType.Warn, guildConfiguration.infractionConfiguration.warnPoints)
-            infractionService.infract(targetMember, guild, user, infraction)
-            respondMenu {
-                createHistoryEmbed(targetMember, user, guild, config, databaseService)
-            }
+            InfractionConversation(databaseService, config, infractionService)
+                    .createInfractionConversation(guild, targetMember, 1, reason, InfractionType.Warn)
+                    .startPublicly(discord, author, channel)
         }
     }
 

--- a/src/main/kotlin/me/ddivad/judgebot/commands/RuleCommands.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/commands/RuleCommands.kt
@@ -1,5 +1,6 @@
 package me.ddivad.judgebot.commands
 
+import com.gitlab.kordlib.core.behavior.edit
 import me.ddivad.judgebot.arguments.RuleArg
 import me.ddivad.judgebot.conversations.rules.AddRuleConversation
 import me.ddivad.judgebot.conversations.rules.ArchiveRuleConversation
@@ -8,9 +9,11 @@ import me.ddivad.judgebot.dataclasses.Configuration
 import me.ddivad.judgebot.embeds.createRuleEmbed
 import me.ddivad.judgebot.embeds.createRulesEmbed
 import me.ddivad.judgebot.embeds.createRulesEmbedDetailed
+import me.ddivad.judgebot.extensions.jumpLink
 import me.ddivad.judgebot.services.DatabaseService
 import me.ddivad.judgebot.services.PermissionLevel
 import me.ddivad.judgebot.services.requiredPermissionLevel
+import me.jakejmattson.discordkt.api.arguments.MessageArg
 import me.jakejmattson.discordkt.api.dsl.commands
 
 @Suppress("unused")
@@ -48,21 +51,33 @@ fun ruleCommands(configuration: Configuration,
     }
 
     guildCommand("rules") {
-        description = "List the rules of this guild."
+        description = "List the rules of this guild. Pass a message ID to edit existing rules embed."
         requiredPermissionLevel = PermissionLevel.Everyone
-        execute {
-            respond {
-                createRulesEmbed(guild, databaseService.guilds.getRules(guild))
+        execute(MessageArg.makeNullableOptional(null)) {
+            val messageToEdit = args.first
+            if (messageToEdit != null) {
+                messageToEdit.edit { this.embed { createRulesEmbed(guild, databaseService.guilds.getRules(guild)) } }
+                respond("Existing embed updated: ${messageToEdit.jumpLink(guild.id.value)}")
+            } else {
+                respond {
+                    createRulesEmbed(guild, databaseService.guilds.getRules(guild))
+                }
             }
         }
     }
 
     guildCommand("longRules") {
-        description = "List the rules (with descriptions) of this guild."
+        description = "List the rules (with descriptions) of this guild. Pass a message ID to edit existing rules embed."
         requiredPermissionLevel = PermissionLevel.Staff
-        execute {
-            respond {
-                createRulesEmbedDetailed(guild, databaseService.guilds.getRules(guild))
+        execute(MessageArg.makeNullableOptional(null)) {
+            val messageToEdit = args.first
+            if (messageToEdit != null) {
+                messageToEdit.edit { this.embed { createRulesEmbedDetailed(guild, databaseService.guilds.getRules(guild)) } }
+                respond("Existing embed updated: ${messageToEdit.jumpLink(guild.id.value)}")
+            } else {
+                respond {
+                    createRulesEmbedDetailed(guild, databaseService.guilds.getRules(guild))
+                }
             }
         }
     }

--- a/src/main/kotlin/me/ddivad/judgebot/conversations/InfractionConversation.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/conversations/InfractionConversation.kt
@@ -4,26 +4,28 @@ import com.gitlab.kordlib.core.entity.Guild
 import com.gitlab.kordlib.core.entity.Member
 import me.ddivad.judgebot.dataclasses.*
 import me.ddivad.judgebot.embeds.createHistoryEmbed
-import me.ddivad.judgebot.embeds.createRuleEmbedForStrike
+import me.ddivad.judgebot.embeds.createInfractionRuleEmbed
 import me.ddivad.judgebot.services.DatabaseService
 import me.ddivad.judgebot.services.infractions.InfractionService
 import me.jakejmattson.discordkt.api.arguments.IntegerArg
 import me.jakejmattson.discordkt.api.dsl.conversation
 
-class StrikeConversation(private val databaseService: DatabaseService,
-                         private val configuration: Configuration,
-                         private val infractionService: InfractionService) {
-    fun createStrikeConversation(guild: Guild, targetUser: Member, weight: Int, infractionReason: String) = conversation("cancel") {
+class InfractionConversation(private val databaseService: DatabaseService,
+                             private val configuration: Configuration,
+                             private val infractionService: InfractionService) {
+    fun createInfractionConversation(guild: Guild, targetUser: Member, weight: Int, infractionReason: String, type: InfractionType) = conversation("cancel") {
         val guildConfiguration = configuration[guild.id.longValue] ?: return@conversation
         val user = databaseService.users.getOrCreateUser(targetUser, guild)
-        val points = weight * guildConfiguration.infractionConfiguration.strikePoints
+        val points = weight *
+                if (type == InfractionType.Strike) guildConfiguration.infractionConfiguration.strikePoints
+                else guildConfiguration.infractionConfiguration.warnPoints
         val rules = databaseService.guilds.getRules(guild)
         val ruleId = if (rules.isNotEmpty()) {
-            respond { createRuleEmbedForStrike(guild, rules) }
+            respond { createInfractionRuleEmbed(guild, rules) }
             val rule = promptMessage(IntegerArg, "Enter `0` for no rule, or rule id to add a rule:")
             if (rule > 0) rule else null
         } else null
-        val infraction = Infraction(this.user.id.value, infractionReason, InfractionType.Strike, points, ruleId)
+        val infraction = Infraction(this.user.id.value, infractionReason, type, points, ruleId)
         infractionService.infract(targetUser, guild, user, infraction)
         respondMenu { createHistoryEmbed(targetUser, user, guild, configuration, databaseService) }
     }

--- a/src/main/kotlin/me/ddivad/judgebot/embeds/InfoEmbeds.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/embeds/InfoEmbeds.kt
@@ -30,16 +30,3 @@ fun EmbedBuilder.createInformationEmbed(guild: Guild, user: Member, information:
         text = guild.name
     }
 }
-
-fun EmbedBuilder.createAlertMessageEmbed(guild: Guild, message: Message, user: User) {
-    color = Color.MAGENTA
-//    author {
-//        name = "Message Flagged"
-//        icon = user.avatar.url
-//    }
-    title = "Message Flagged"
-    addInlineField("Flagged by:", user.mention)
-    addInlineField("Sent by:", message.author!!.mention)
-    addInlineField("Channel:", message.channel.mention)
-    addField("Link to message:", message.jumpLink(guild.id.value))
-}

--- a/src/main/kotlin/me/ddivad/judgebot/embeds/InfoEmbeds.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/embeds/InfoEmbeds.kt
@@ -2,10 +2,14 @@ package me.ddivad.judgebot.embeds
 
 import com.gitlab.kordlib.core.entity.Guild
 import com.gitlab.kordlib.core.entity.Member
+import com.gitlab.kordlib.core.entity.Message
+import com.gitlab.kordlib.core.entity.User
 import com.gitlab.kordlib.rest.Image
 import com.gitlab.kordlib.rest.builder.message.EmbedBuilder
 import me.ddivad.judgebot.dataclasses.*
+import me.ddivad.judgebot.extensions.jumpLink
 import me.jakejmattson.discordkt.api.extensions.addField
+import me.jakejmattson.discordkt.api.extensions.addInlineField
 import java.awt.Color
 
 fun EmbedBuilder.createInformationEmbed(guild: Guild, user: Member, information: Info) {
@@ -25,4 +29,17 @@ fun EmbedBuilder.createInformationEmbed(guild: Guild, user: Member, information:
         icon = guild.getIconUrl(Image.Format.PNG) ?: ""
         text = guild.name
     }
+}
+
+fun EmbedBuilder.createAlertMessageEmbed(guild: Guild, message: Message, user: User) {
+    color = Color.MAGENTA
+//    author {
+//        name = "Message Flagged"
+//        icon = user.avatar.url
+//    }
+    title = "Message Flagged"
+    addInlineField("Flagged by:", user.mention)
+    addInlineField("Sent by:", message.author!!.mention)
+    addInlineField("Channel:", message.channel.mention)
+    addField("Link to message:", message.jumpLink(guild.id.value))
 }

--- a/src/main/kotlin/me/ddivad/judgebot/embeds/RuleEmbeds.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/embeds/RuleEmbeds.kt
@@ -41,7 +41,7 @@ fun EmbedBuilder.createRulesEmbed(guild: Guild, rules: List<Rule>) {
     }
 }
 
-fun EmbedBuilder.createRuleEmbedForStrike(guild: Guild, rules: List<Rule>) {
+fun EmbedBuilder.createInfractionRuleEmbed(guild: Guild, rules: List<Rule>) {
     title = "**__Available Rules__**"
     color = Color.MAGENTA
     description = ""

--- a/src/main/kotlin/me/ddivad/judgebot/listeners/MemberReactionListeners.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/listeners/MemberReactionListeners.kt
@@ -1,13 +1,16 @@
 package me.ddivad.judgebot.listeners
 
+import com.gitlab.kordlib.core.behavior.channel.createEmbed
 import com.gitlab.kordlib.core.behavior.getChannelOf
 import com.gitlab.kordlib.core.entity.channel.TextChannel
 import com.gitlab.kordlib.core.event.message.ReactionAddEvent
 import com.gitlab.kordlib.kordx.emoji.Emojis
 import com.gitlab.kordlib.kordx.emoji.addReaction
 import me.ddivad.judgebot.dataclasses.Configuration
+import me.ddivad.judgebot.embeds.createAlertMessageEmbed
 import me.ddivad.judgebot.extensions.jumpLink
 import me.jakejmattson.discordkt.api.dsl.listeners
+import me.jakejmattson.discordkt.api.extensions.isSelf
 import me.jakejmattson.discordkt.api.extensions.toSnowflake
 
 @Suppress("unused")
@@ -21,8 +24,12 @@ fun onMemberReactionAdd(configuration: Configuration) = listeners {
             guildConfiguration.reactions.flagMessageReaction -> {
                 message.deleteReaction(this.emoji)
                 guild.asGuild().getChannelOf<TextChannel>(guildConfiguration.loggingConfiguration.alertChannel.toSnowflake()).asChannel()
-                        .createMessage("User ${user.mention} flagged the message: ${this.message.asMessage().jumpLink(guild.id.value)} in: ${this.channel.mention}")
-                        .addReaction(Emojis.whiteCheckMark)
+                        .createMessage("**Message Flagged**" +
+                                "\n**User**: ${user.mention}" +
+                                "\n**Channel**: ${message.channel.mention}" +
+                                "\n**Author:** ${message.asMessage().author?.mention}" +
+                                "\n**Message:** ${message.asMessage().jumpLink(guild.id.value)}")
+                        .addReaction(Emojis.question)
             }
         }
     }

--- a/src/main/kotlin/me/ddivad/judgebot/listeners/StaffReactionListeners.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/listeners/StaffReactionListeners.kt
@@ -2,6 +2,8 @@ package me.ddivad.judgebot.listeners
 
 import com.gitlab.kordlib.common.exception.RequestException
 import com.gitlab.kordlib.core.event.message.ReactionAddEvent
+import com.gitlab.kordlib.kordx.emoji.Emojis
+import com.gitlab.kordlib.kordx.emoji.addReaction
 import me.ddivad.judgebot.arguments.isHigherRankedThan
 import me.ddivad.judgebot.dataclasses.Configuration
 import me.ddivad.judgebot.embeds.createMessageDeleteEmbed
@@ -11,6 +13,7 @@ import me.ddivad.judgebot.services.PermissionLevel
 import me.ddivad.judgebot.services.PermissionsService
 import me.ddivad.judgebot.services.infractions.MuteService
 import me.jakejmattson.discordkt.api.dsl.listeners
+import me.jakejmattson.discordkt.api.extensions.isSelf
 import me.jakejmattson.discordkt.api.extensions.sendPrivateMessage
 
 @Suppress("unused")
@@ -24,32 +27,37 @@ fun onStaffReactionAdd(muteService: MuteService,
         if (!guildConfiguration?.reactions!!.enabled) return@on
         val member = user.asMemberOrNull(guild.id) ?: return@on
         val messageAuthor = message.asMessage().author?.asMemberOrNull(guild.id) ?: return@on
-        
+        val msg = message.asMessage()
+
         if (permissionsService.hasPermission(member, PermissionLevel.Moderator) && !member.isHigherRankedThan(permissionsService, messageAuthor)) {
             when (this.emoji.name) {
                 guildConfiguration.reactions.gagReaction -> {
-                    message.deleteReaction(this.emoji)
+                    msg.deleteReaction(this.emoji)
                     muteService.gag(messageAuthor.asMember(guild.id))
                     member.sendPrivateMessage("${messageAuthor.mention} gagged.")
                 }
                 guildConfiguration.reactions.historyReaction -> {
-                    message.deleteReaction(this.emoji)
+                    msg.deleteReaction(this.emoji)
                     val target = databaseService.users.getOrCreateUser(messageAuthor, guild.asGuild())
                     member.sendPrivateMessage { createSelfHistoryEmbed(messageAuthor, target, guild.asGuild(), configuration) }
                 }
                 guildConfiguration.reactions.deleteMessageReaction -> {
-                    val content = message.asMessage()
-                    message.deleteReaction(this.emoji)
-                    message.delete()
+                    msg.deleteReaction(this.emoji)
+                    msg.delete()
                     try {
                         messageAuthor.sendPrivateMessage {
-                            createMessageDeleteEmbed(guild, content)
+                            createMessageDeleteEmbed(guild, msg)
                         }
                     } catch (ex: RequestException) {
                         this.user.sendPrivateMessage("User ${messageAuthor.mention} has DM's disabled." +
                                 " Message deleted without notification.")
                     }
 
+                }
+                Emojis.question.unicode -> {
+                    if (this.user.isSelf() || msg.author != this.message.kord.getSelf()) return@on
+                    msg.deleteReaction(this.emoji)
+                    msg.addReaction(Emojis.whiteCheckMark)
                 }
             }
         }

--- a/src/main/kotlin/me/ddivad/judgebot/services/infractions/MuteService.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/services/infractions/MuteService.kt
@@ -98,6 +98,7 @@ class MuteService(val configuration: Configuration,
     private suspend fun initialiseMuteTimers(guild: Guild) {
         databaseService.guilds.getPunishmentsForGuild(guild, InfractionType.Mute).forEach {
             if (it.clearTime != null) {
+                println("Adding Existing Timer :: UserId: ${it.userId}, GuildId: ${guild.id.value}, PunishmentId: ${it.id}")
                 val difference = it.clearTime - DateTime.now().millis
                 val member = guild.getMemberOrNull(it.userId.toSnowflake()) ?: return
                 val user = member.asUser()


### PR DESCRIPTION
# feat: miscellaneous updates

Miscellaneous updates:

- Change warn flow to allow for rules to be added.
- Update rule embed commands to take an optional messageId. When passed, it will update that message instead of posting a new one.
- Update Alert message to show more information about the message.
- Update reactions for Alert message to make the staff flow easier to follow.
- Update Strike conversation -> Infraction conversation.
- Add logging when existing punishments are being re-applied on startup.