### PR TITLE
fix: prevent users being created if they have left the guild within 5 minutes

### DIFF
--- a/src/main/kotlin/me/ddivad/judgebot/listeners/JoinLeaveListener.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/listeners/JoinLeaveListener.kt
@@ -33,7 +33,9 @@ fun onGuildMemberLeave(databaseService: DatabaseService) = listeners {
         // Add delay before creating user in case they are banned (raid, etc...)
         GlobalScope.launch {
             delay(1000 * 60 * 5)
-            databaseService.users.getOrCreateUser(member, guild)
+            guild.kord.getUser(member.id)?.let {
+                databaseService.users.getOrCreateUser(member, guild)
+            }
         }
     }
 }


### PR DESCRIPTION
# fix: prevent users being created if they have left the guild within 5 minutes

Fixes the join listener to stop it creating users if they leave or get banned within the first 5 minutes.