### PR TITLE
feat: history embed improvements, general fixes

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -51,16 +51,15 @@
 | rules       | (Message) | List the rules of this guild. Pass a message ID to edit existing rules embed.                     |
 
 ## User
-| Commands     | Arguments                                   | Description                                                |
-| ------------ | ------------------------------------------- | ---------------------------------------------------------- |
-| ban          | LowerMemberArg, (Delete message days), Text | Ban a member from this guild.                              |
-| getBanReason | User                                        | Get a ban reason for a banned user                         |
-| history, h   | User                                        | Use this to view a user's record.                          |
-| selfHistory  |                                             | View your infraction history (contents will be DM'd)       |
-| setBanReason | User, Text                                  | Set a ban reason for a banned user                         |
-| status, st   | User                                        | Use this to view a user's status card.                     |
-| unban        | User                                        | Unban a banned member from this guild.                     |
-| whatpfp      | User                                        | Perform a reverse image search of a User's profile picture |
+| Commands     | Arguments                                 | Description                                                |
+| ------------ | ----------------------------------------- | ---------------------------------------------------------- |
+| ban          | LowerUserArg, (Delete message days), Text | Ban a member from this guild.                              |
+| getBanReason | User                                      | Get a ban reason for a banned user                         |
+| history, h   | User                                      | Use this to view a user's record.                          |
+| selfHistory  |                                           | View your infraction history (contents will be DM'd)       |
+| setBanReason | User, Text                                | Set a ban reason for a banned user                         |
+| unban        | User                                      | Unban a banned member from this guild.                     |
+| whatpfp      | User                                      | Perform a reverse image search of a User's profile picture |
 
 ## Utility
 | Commands | Arguments | Description          |

--- a/src/main/kotlin/me/ddivad/judgebot/arguments/LowerUserArg.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/arguments/LowerUserArg.kt
@@ -1,0 +1,30 @@
+package me.ddivad.judgebot.arguments
+
+import com.gitlab.kordlib.core.entity.User
+import me.ddivad.judgebot.services.PermissionsService
+import me.jakejmattson.discordkt.api.arguments.ArgumentResult
+import me.jakejmattson.discordkt.api.arguments.ArgumentType
+import me.jakejmattson.discordkt.api.dsl.CommandEvent
+import me.jakejmattson.discordkt.api.arguments.Success
+import me.jakejmattson.discordkt.api.arguments.Error
+import me.jakejmattson.discordkt.api.extensions.toSnowflakeOrNull
+
+open class LowerUserArg(override val name: String = "LowerUserArg") : ArgumentType<User>() {
+    companion object : LowerUserArg()
+
+    override fun generateExamples(event: CommandEvent<*>) = mutableListOf("@User", "197780697866305536", "302134543639511050")
+
+    override suspend fun convert(arg: String, args: List<String>, event: CommandEvent<*>): ArgumentResult<User> {
+        val permissionsService = event.discord.getInjectionObjects(PermissionsService::class)
+        val guild = event.guild ?: return Error("No guild found")
+
+        val user = arg.toSnowflakeOrNull()?.let { guild.kord.getUser(it) } ?: return Error("User Not Found")
+        val member = guild.getMemberOrNull(user.id) ?: return Success(user)
+
+        return when {
+            event.author.asMember(event.guild!!.id).isHigherRankedThan(permissionsService, member) ->
+                Error("You don't have the permission to use this command on the target user")
+            else -> Success(member.asUser())
+        }
+    }
+}

--- a/src/main/kotlin/me/ddivad/judgebot/commands/InfoCommands.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/commands/InfoCommands.kt
@@ -1,8 +1,12 @@
 package me.ddivad.judgebot.commands
 
+import com.gitlab.kordlib.common.exception.RequestException
+import com.gitlab.kordlib.kordx.emoji.Emojis
+import com.gitlab.kordlib.kordx.emoji.addReaction
 import me.ddivad.judgebot.arguments.LowerMemberArg
 import me.ddivad.judgebot.dataclasses.Info
 import me.ddivad.judgebot.embeds.createInformationEmbed
+import me.ddivad.judgebot.extensions.testDmStatus
 import me.ddivad.judgebot.services.DatabaseService
 import me.ddivad.judgebot.services.PermissionLevel
 import me.ddivad.judgebot.services.requiredPermissionLevel
@@ -18,6 +22,14 @@ fun createInformationCommands(databaseService: DatabaseService) = commands("Info
         requiredPermissionLevel = PermissionLevel.Moderator
         execute(LowerMemberArg, EveryArg("Info Content")) {
             val (target, content) = args
+            try {
+                target.testDmStatus()
+                this.message.addReaction(Emojis.whiteCheckMark)
+            } catch (ex: RequestException) {
+                this.message.addReaction(Emojis.x)
+                respond("Target user has DM's disabled. Info will not be sent.")
+                return@execute
+            }
             val user = databaseService.users.getOrCreateUser(target, guild)
             val information = Info(content, author.id.value)
             databaseService.users.addInfo(guild, user, information)

--- a/src/main/kotlin/me/ddivad/judgebot/commands/InfractionCommands.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/commands/InfractionCommands.kt
@@ -1,6 +1,8 @@
 package me.ddivad.judgebot.commands
 
 import com.gitlab.kordlib.common.exception.RequestException
+import com.gitlab.kordlib.kordx.emoji.Emojis
+import com.gitlab.kordlib.kordx.emoji.addReaction
 import me.ddivad.judgebot.arguments.LowerMemberArg
 import me.ddivad.judgebot.conversations.InfractionConversation
 import me.ddivad.judgebot.dataclasses.Configuration
@@ -34,7 +36,9 @@ fun createInfractionCommands(databaseService: DatabaseService,
             }
             try {
                 targetMember.testDmStatus()
+                this.message.addReaction(Emojis.whiteCheckMark)
             } catch (ex: RequestException) {
+                this.message.addReaction(Emojis.x)
                 respond("Target user has DM's disabled. Infraction cancelled.")
                 return@execute
             }
@@ -51,7 +55,9 @@ fun createInfractionCommands(databaseService: DatabaseService,
             val (targetMember, reason) = args
             try {
                 targetMember.testDmStatus()
+                this.message.addReaction(Emojis.whiteCheckMark)
             } catch (ex: RequestException) {
+                this.message.addReaction(Emojis.x)
                 respond("Target user has DM's disabled. Infraction cancelled.")
                 return@execute
             }
@@ -68,7 +74,9 @@ fun createInfractionCommands(databaseService: DatabaseService,
             val (cancel, targetMember) = args
             try {
                 targetMember.testDmStatus()
+                this.message.addReaction(Emojis.whiteCheckMark)
             } catch (ex: RequestException) {
+                this.message.addReaction(Emojis.x)
                 respond("Target user has DM's disabled. Infraction cancelled.")
                 return@execute
             }

--- a/src/main/kotlin/me/ddivad/judgebot/commands/MuteCommands.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/commands/MuteCommands.kt
@@ -1,6 +1,8 @@
 package me.ddivad.judgebot.commands
 
 import com.gitlab.kordlib.common.exception.RequestException
+import com.gitlab.kordlib.kordx.emoji.Emojis
+import com.gitlab.kordlib.kordx.emoji.addReaction
 import me.ddivad.judgebot.arguments.LowerMemberArg
 import me.ddivad.judgebot.extensions.testDmStatus
 import me.ddivad.judgebot.services.*
@@ -21,9 +23,10 @@ fun createMuteCommands(muteService: MuteService) = commands("Mute") {
             val (targetMember, length, reason) = args
             try {
                 targetMember.testDmStatus()
+                this.message.addReaction(Emojis.whiteCheckMark)
             } catch (ex: RequestException) {
-                respond("Unable to contact the target user. Infraction cancelled.")
-                return@execute
+                this.message.addReaction(Emojis.x)
+                respond("User has DM's disabled and won't receive message.")
             }
             muteService.applyMute(targetMember, length.roundToLong() * 1000, reason)
             respond("User ${targetMember.mention} has been muted")
@@ -50,12 +53,6 @@ fun createMuteCommands(muteService: MuteService) = commands("Mute") {
         requiredPermissionLevel = PermissionLevel.Moderator
         execute(LowerMemberArg) {
             val targetMember = args.first
-            try {
-                targetMember.testDmStatus()
-            } catch (ex: RequestException) {
-                respond("Unable to contact the target user. Infraction cancelled.")
-                return@execute
-            }
             if (muteService.checkRoleState(guild, targetMember) == RoleState.Tracked) {
                 respond("User ${targetMember.mention} is already muted")
                 return@execute

--- a/src/main/kotlin/me/ddivad/judgebot/commands/UserCommands.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/commands/UserCommands.kt
@@ -1,15 +1,16 @@
 package me.ddivad.judgebot.commands
 
 import me.ddivad.judgebot.arguments.LowerMemberArg
+import me.ddivad.judgebot.arguments.LowerUserArg
 import me.ddivad.judgebot.dataclasses.*
 import me.ddivad.judgebot.embeds.createHistoryEmbed
 import me.ddivad.judgebot.embeds.createSelfHistoryEmbed
-import me.ddivad.judgebot.embeds.createStatusEmbed
 import me.ddivad.judgebot.services.DatabaseService
 import me.ddivad.judgebot.services.LoggingService
 import me.ddivad.judgebot.services.PermissionLevel
 import me.ddivad.judgebot.services.infractions.BanService
 import me.ddivad.judgebot.services.requiredPermissionLevel
+import me.jakejmattson.discordkt.api.arguments.EitherArg
 import me.jakejmattson.discordkt.api.arguments.EveryArg
 import me.jakejmattson.discordkt.api.arguments.IntegerArg
 import me.jakejmattson.discordkt.api.arguments.UserArg
@@ -34,16 +35,6 @@ fun createUserCommands(databaseService: DatabaseService,
         }
     }
 
-    guildCommand("status", "st") {
-        description = "Use this to view a user's status card."
-        requiredPermissionLevel = PermissionLevel.Moderator
-        execute(UserArg) {
-            val user = databaseService.users.getOrCreateUser(args.first, guild)
-            databaseService.users.incrementUserHistory(user, guild)
-            createStatusEmbed(args.first, user, guild, config)
-        }
-    }
-
     guildCommand("whatpfp") {
         description = "Perform a reverse image search of a User's profile picture"
         requiredPermissionLevel = PermissionLevel.Moderator
@@ -62,11 +53,11 @@ fun createUserCommands(databaseService: DatabaseService,
     guildCommand("ban") {
         description = "Ban a member from this guild."
         requiredPermissionLevel = PermissionLevel.Staff
-        execute(LowerMemberArg, IntegerArg("Delete message days").makeOptional(1), EveryArg) {
+        execute(LowerUserArg, IntegerArg("Delete message days").makeOptional(1), EveryArg) {
             val (target, deleteDays, reason) = args
             val ban = Punishment(target.id.value, InfractionType.Ban , reason, author.id.value)
             banService.banUser(target, guild, ban, deleteDays).also {
-                loggingService.userBanned(guild, target.asUser(), ban)
+                loggingService.userBanned(guild, target, ban)
                 respond("User ${target.mention} banned")
             }
         }

--- a/src/main/kotlin/me/ddivad/judgebot/embeds/UserEmbeds.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/embeds/UserEmbeds.kt
@@ -7,21 +7,14 @@ import com.gitlab.kordlib.rest.Image
 import com.gitlab.kordlib.rest.builder.message.EmbedBuilder
 import me.ddivad.judgebot.dataclasses.*
 import me.ddivad.judgebot.services.DatabaseService
-import me.ddivad.judgebot.util.timeBetween
-import me.ddivad.judgebot.util.timeToString
-import me.jakejmattson.discordkt.api.dsl.CommandEvent
+import me.ddivad.judgebot.util.*
 import me.jakejmattson.discordkt.api.dsl.MenuBuilder
 import me.jakejmattson.discordkt.api.extensions.addField
 import me.jakejmattson.discordkt.api.extensions.addInlineField
 import org.joda.time.DateTime
 import java.awt.Color
 import java.text.SimpleDateFormat
-import java.time.Instant
-import java.time.ZoneOffset
-import java.time.format.DateTimeFormatter
-import java.time.format.FormatStyle
 import java.util.*
-import java.util.concurrent.TimeUnit
 
 suspend fun MenuBuilder.createHistoryEmbed(
         target: User,
@@ -30,44 +23,48 @@ suspend fun MenuBuilder.createHistoryEmbed(
         config: Configuration,
         databaseService: DatabaseService
 ) {
-    val userGuildDetails = member.getGuildInfo(guild.id.value)
-    val notes = userGuildDetails.notes
-    val information = userGuildDetails.info
-    val infractions = userGuildDetails.infractions
-    val paginatedNotes = notes.chunked(4)
+    val userRecord = member.getGuildInfo(guild.id.value)
+    val paginatedNotes = userRecord.notes.chunked(4)
     val totalMenuPages = 1 + 1 + 1 + 1 + if (paginatedNotes.isNotEmpty()) paginatedNotes.size else 1
-    val maxPoints = config[guild.id.longValue]?.infractionConfiguration?.pointCeiling
+    val guildConfiguration = config[guild.id.longValue]!!
+    val embedColor = getEmbedColour(guild, target, databaseService)
+    this.apply {
+        buildOverviewPage(guild, guildConfiguration, target, userRecord, embedColor, totalMenuPages, databaseService)
+        buildInfractionPage(guild, target, userRecord, embedColor, totalMenuPages)
+        buildNotesPages(guild, guildConfiguration, target, userRecord, embedColor, totalMenuPages)
+        buildInformationPage(guild, guildConfiguration, target, userRecord, embedColor, totalMenuPages)
+        buildJoinLeavePage(guild, target, userRecord, embedColor, totalMenuPages)
+    }
+}
+
+private suspend fun MenuBuilder.buildOverviewPage(
+        guild: Guild,
+        config: GuildConfiguration,
+        target: User,
+        userRecord: GuildMemberDetails,
+        embedColor: Color,
+        totalPages: Int,
+        databaseService: DatabaseService) {
     page {
-        color = Color.MAGENTA
+        color = embedColor
         title = "${target.asUser().tag}: Overview"
         thumbnail {
             url = target.asUser().avatar.url
         }
         val memberInGuild = target.asMemberOrNull(guild.id)
-        addInlineField("Notes", "${notes.size}")
-        addInlineField("Infractions", "${infractions.size}")
-        addInlineField("Points", "**${member.getPoints(guild)} / $maxPoints**")
-        addInlineField("History Invokes", "${userGuildDetails.historyCount}")
+        addInlineField("Notes", "${userRecord.notes.size}")
+        addInlineField("Infractions", "${userRecord.infractions.size}")
+        addInlineField("Points", "**${userRecord.points} / ${config.infractionConfiguration.pointCeiling}**")
+        addInlineField("History Invokes", "${userRecord.historyCount}")
         addInlineField("Creation date", formatOffsetTime(target.id.timeStamp))
         if (memberInGuild != null) {
             addInlineField("Join date", formatOffsetTime(memberInGuild.joinedAt))
-        } else {
-            addField("Status", "```User is not in this guild```")
-        }
+        } else addInlineField("", "")
 
-        val currentPunishments = databaseService.guilds.getPunishmentsForUser(guild, target.asUser())
-        if (currentPunishments.isNotEmpty()) {
-            addField("", "**__Active Punishments__**")
-            currentPunishments.forEach {
-                addField(
-                        "**${it.type}** with **${timeBetween(DateTime(it.clearTime))}** left.",
-                        ""
-                )
-            }
-        } else addField("", "")
+        getStatus(guild, target, databaseService)?.let { addField("Status", it) }
 
-        if (infractions.size > 0) {
-            val lastInfraction = userGuildDetails.infractions[userGuildDetails.infractions.size - 1]
+        if (userRecord.infractions.size > 0) {
+            val lastInfraction = userRecord.infractions[userRecord.infractions.size - 1]
             addField(
                     "**__Most Recent Infraction__**",
                     "Type: **${lastInfraction.type}** :: Weight: **${lastInfraction.points}**\n " +
@@ -76,28 +73,36 @@ suspend fun MenuBuilder.createHistoryEmbed(
                             "Punishment: **${lastInfraction.punishment?.punishment}** ${getDurationText(lastInfraction.punishment)}\n" +
                             lastInfraction.reason
             )
-        } else addField("", "**User has no recent infractions.**")
+        } else addField("", "**User has no recent infractions**")
         footer {
             icon = guild.getIconUrl(Image.Format.PNG) ?: ""
-            text = "Page 1 of $totalMenuPages"
+            text = "Page 1 of $totalPages"
         }
     }
+}
 
+private suspend fun MenuBuilder.buildInfractionPage(
+        guild: Guild,
+        target: User,
+        userRecord: GuildMemberDetails,
+        embedColor: Color,
+        totalPages: Int
+) {
     page {
-        color = Color.MAGENTA
+        color = embedColor
         title = "${target.asUser().tag}: Infractions"
         thumbnail {
             url = target.asUser().avatar.url
         }
-        val warnings = infractions.filter { it.type == InfractionType.Warn }
-        val strikes = infractions.filter { it.type == InfractionType.Strike }
-        val bans = infractions.filter { it.punishment?.punishment == PunishmentType.BAN }
+        val warnings = userRecord.infractions.filter { it.type == InfractionType.Warn }
+        val strikes = userRecord.infractions.filter { it.type == InfractionType.Strike }
+        val bans = userRecord.infractions.filter { it.punishment?.punishment == PunishmentType.BAN }
 
         addInlineField("Warns", "${warnings.size}")
         addInlineField("Strikes", "${strikes.size}")
         addInlineField("Bans", "${bans.size}")
 
-        if (infractions.isEmpty()) addField("", "**User has no infractions.**")
+        if (userRecord.infractions.isEmpty()) addField("", "**User has no infractions**")
         if (warnings.isNotEmpty()) addField("", "**__Warnings__**")
         warnings.forEachIndexed { _, infraction ->
             val moderator = guild.kord.getUser(Snowflake(infraction.moderator))?.username
@@ -124,41 +129,50 @@ suspend fun MenuBuilder.createHistoryEmbed(
 
         footer {
             icon = guild.getIconUrl(Image.Format.PNG) ?: ""
-            text = "Page 2 of $totalMenuPages"
+            text = "Page 2 of $totalPages"
         }
     }
+}
 
-    if (notes.isEmpty()) {
+private suspend fun MenuBuilder.buildNotesPages(
+        guild: Guild,
+        config: GuildConfiguration,
+        target: User,
+        userRecord: GuildMemberDetails,
+        embedColor: Color,
+        totalPages: Int
+) {
+    val paginatedNotes = userRecord.notes.chunked(4)
+    if (userRecord.notes.isEmpty()) {
         page {
-            color = Color.MAGENTA
+            color = embedColor
             title = "${target.asUser().tag}: Notes"
             thumbnail {
                 url = target.asUser().avatar.url
             }
 
-            addInlineField("Notes", "${notes.size}")
-            addInlineField("Information", "${information.size}")
-            addInlineField("Points", "**${member.getPoints(guild)} / $maxPoints**")
+            addInlineField("Notes", "${userRecord.notes.size}")
+            addInlineField("Information", "${userRecord.info.size}")
+            addInlineField("Points", "**${userRecord.points} / ${config.infractionConfiguration.pointCeiling}**")
 
-            addField("", "**__Notes:__**")
-            addField("**No Notes**", "User has no notes written.")
+            addField("", "**User has no notes**")
             footer {
                 icon = guild.getIconUrl(Image.Format.PNG) ?: ""
-                text = "Page 3 of $totalMenuPages"
+                text = "Page 3 of $totalPages"
             }
         }
     }
 
     paginatedNotes.forEachIndexed { index, list ->
         page {
-            color = Color.MAGENTA
+            color = embedColor
             title = "${target.asUser().tag}: Notes" + if (paginatedNotes.size > 1) "(${index + 1})" else ""
             thumbnail {
                 url = target.asUser().avatar.url
             }
-            addInlineField("Notes", "${notes.size}")
-            addInlineField("Information", "${information.size}")
-            addInlineField("Points", "**${member.getPoints(guild)} / $maxPoints**")
+            addInlineField("Notes", "${userRecord.notes.size}")
+            addInlineField("Information", "${userRecord.info.size}")
+            addInlineField("Points", "**${userRecord.points} / ${config.infractionConfiguration.pointCeiling}**")
 
             list.forEachIndexed { _, note ->
                 val moderator = guild.kord.getUser(Snowflake(note.moderator))?.username
@@ -171,61 +185,60 @@ suspend fun MenuBuilder.createHistoryEmbed(
             }
             footer {
                 icon = guild.getIconUrl(Image.Format.PNG) ?: ""
-                text = "Page ${3 + index} of $totalMenuPages"
+                text = "Page ${3 + index} of $totalPages"
             }
         }
     }
+}
 
-    if (information.isEmpty()) {
-        page {
-            color = Color.MAGENTA
-            title = "${target.asUser().tag}: Information"
-            thumbnail {
-                url = target.asUser().avatar.url
-            }
-
-            addInlineField("Notes", "${notes.size}")
-            addInlineField("Information", "${information.size}")
-            addInlineField("Points", "**${member.getPoints(guild)} / $maxPoints**")
-
-            addField("", "**__Information:__**")
-            addField("**No Information**", "User has no information records.")
-            footer {
-                icon = guild.getIconUrl(Image.Format.PNG) ?: ""
-                text = "Page ${3 + if (paginatedNotes.isEmpty()) 1 else paginatedNotes.size} of $totalMenuPages"
-            }
-        }
-    } else {
-        page {
-            color = Color.MAGENTA
-            title = "${target.asUser().tag}: Information"
-            thumbnail {
-                url = target.asUser().avatar.url
-            }
-            addInlineField("Notes", "${notes.size}")
-            addInlineField("Information", "${information.size}")
-            addInlineField("Points", "**${member.getPoints(guild)} / $maxPoints**")
-
-            information.forEachIndexed { _, info ->
-                val moderator = guild.kord.getUser(Snowflake(info.moderator))?.username
-
-                addField(
-                        "ID :: ${info.id} :: Staff :: __${moderator}__",
-                        "Sent by **${moderator}** on **${SimpleDateFormat("dd/MM/yyyy").format(Date(info.dateTime))}**\n" +
-                                info.message
-                )
-            }
-            footer {
-                icon = guild.getIconUrl(Image.Format.PNG) ?: ""
-                text = "Page ${3 + if (paginatedNotes.isEmpty()) 1 else paginatedNotes.size} of $totalMenuPages"
-            }
-        }
-    }
-
+private suspend fun MenuBuilder.buildInformationPage(
+        guild: Guild,
+        config: GuildConfiguration,
+        target: User,
+        userRecord: GuildMemberDetails,
+        embedColor: Color,
+        totalPages: Int
+) {
+    val paginatedNotes = userRecord.notes.chunked(4)
     page {
-        val history = userGuildDetails.leaveHistory
+        color = embedColor
+        title = "${target.asUser().tag}: Information"
+        thumbnail {
+            url = target.asUser().avatar.url
+        }
+        addInlineField("Notes", "${userRecord.notes.size}")
+        addInlineField("Information", "${userRecord.info.size}")
+        addInlineField("Points", "**${userRecord.points} / ${config.infractionConfiguration.pointCeiling}**")
+
+        if (userRecord.info.isEmpty()) addField("", "**User has no information**")
+        userRecord.info.forEachIndexed { _, info ->
+            val moderator = guild.kord.getUser(Snowflake(info.moderator))?.username
+            addField(
+                    "ID :: ${info.id} :: Staff :: __${moderator}__",
+                    "Sent by **${moderator}** on **${SimpleDateFormat("dd/MM/yyyy").format(Date(info.dateTime))}**\n" +
+                            info.message
+            )
+        }
+        footer {
+            icon = guild.getIconUrl(Image.Format.PNG) ?: ""
+            text = "Page ${3 + if (paginatedNotes.isEmpty()) 1 else paginatedNotes.size} of $totalPages"
+        }
+    }
+}
+
+private suspend fun MenuBuilder.buildJoinLeavePage(
+        guild: Guild,
+        target: User,
+        userRecord: GuildMemberDetails,
+        embedColor: Color,
+        totalPages: Int
+) {
+    page {
+        val history = userRecord.leaveHistory
         val leaves = history.filter { it.leaveDate != null }
-        color = Color.MAGENTA
+        val paginatedNotes = userRecord.notes.chunked(4)
+
+        color = embedColor
         title = "${target.asUser().tag}: Join / Leave"
         thumbnail {
             url = target.asUser().avatar.url
@@ -235,7 +248,7 @@ suspend fun MenuBuilder.createHistoryEmbed(
         addInlineField("", "")
         addInlineField("Leaves:", leaves.size.toString())
         addField("", "")
-        userGuildDetails.leaveHistory.forEachIndexed { index, record ->
+        userRecord.leaveHistory.forEachIndexed { index, record ->
             addInlineField("Record", "#${index + 1}")
             addInlineField("Joined", SimpleDateFormat("dd/MM/yyyy").format(Date(record.joinDate!!)))
             addInlineField("Left", if (record.leaveDate == null) "-" else SimpleDateFormat("dd/MM/yyyy").format(Date(record.joinDate)))
@@ -243,7 +256,7 @@ suspend fun MenuBuilder.createHistoryEmbed(
         }
         footer {
             icon = guild.getIconUrl(Image.Format.PNG) ?: ""
-            text = "Page ${4 + if (paginatedNotes.isEmpty()) 1 else paginatedNotes.size} of $totalMenuPages"
+            text = "Page ${4 + if (paginatedNotes.isEmpty()) 1 else paginatedNotes.size} of $totalPages"
         }
     }
 }
@@ -263,40 +276,22 @@ private fun getDurationText(level: PunishmentLevel?): String {
     }
 }
 
-suspend fun CommandEvent<*>.createStatusEmbed(target: User,
-                                              member: GuildMember,
-                                              guild: Guild,
-                                              config: Configuration) = respond {
-    val userGuildDetails = member.getGuildInfo(guild.id.value)
-    val notes = userGuildDetails.notes
-    val infractions = userGuildDetails.infractions
-    val maxPoints = config[guild.id.longValue]?.infractionConfiguration?.pointCeiling
-    val memberInGuild = target.asMemberOrNull(guild.id)
-
-    color = discord.configuration.theme
-    title = "${target.asUser().tag}'s Record"
-    thumbnail {
-        url = target.asUser().avatar.url
-    }
-
-    if (memberInGuild == null) addField("**__User not currently in this guild__**", "")
-    addInlineField("Notes", "${notes.size}")
-    addInlineField("Infractions", "${infractions.size}")
-    addInlineField("Points", "**${member.getPoints(guild)} / $maxPoints**")
-    if (memberInGuild != null) addInlineField("Join date", formatOffsetTime(memberInGuild.joinedAt))
-    addInlineField("Creation date", formatOffsetTime(target.id.timeStamp))
-    addInlineField("History Invokes", "${userGuildDetails.historyCount}")
+private suspend fun getEmbedColour(guild: Guild, target: User, databaseService: DatabaseService): Color {
+    if (guild.getBanOrNull(target.id) != null) return Color.RED
+    if (target.asMemberOrNull(guild.id) == null) return Color.BLACK
+    if (databaseService.guilds.getPunishmentsForUser(guild, target).isNotEmpty()) return Color.ORANGE
+    return Color.MAGENTA
 }
 
-private fun formatOffsetTime(time: Instant): String {
-    val days = TimeUnit.MILLISECONDS.toDays(DateTime.now().millis - time.toEpochMilli())
-    val formatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT).withLocale(Locale.UK).withZone(ZoneOffset.UTC)
-    return if (days > 4) {
-        "${formatter.format(time)}\n($days days ago)"
-    } else {
-        val hours = TimeUnit.MILLISECONDS.toHours(DateTime.now().millis - time.toEpochMilli())
-        "${formatter.format(time)}\n($hours hours ago)"
+private suspend fun getStatus(guild: Guild, target: User, databaseService: DatabaseService): String? {
+    guild.getBanOrNull(target.id)?.let {
+        return "```css\nUser is banned with reason:\n${it.reason}```"
     }
+    if (target.asMemberOrNull(guild.id) == null) return "```css\nUser not currently in this guild```"
+    databaseService.guilds.getPunishmentsForUser(guild, target).firstOrNull()?.let {
+        return "```css\nActive ${it.type} with ${timeBetween(DateTime(it.clearTime))} left```"
+    }
+    return null
 }
 
 suspend fun EmbedBuilder.createSelfHistoryEmbed(target: User,
@@ -318,7 +313,7 @@ suspend fun EmbedBuilder.createSelfHistoryEmbed(target: User,
     addInlineField("Infractions", "${infractions.size}")
     addInlineField("Points", "**${member.getPoints(guild)} / $maxPoints**")
 
-    if (infractions.size == 0) {
+    if (infractions.isEmpty()) {
         addField("", "")
         addField("No infractions issued.", "")
     } else {
@@ -336,7 +331,7 @@ suspend fun EmbedBuilder.createSelfHistoryEmbed(target: User,
             )
         }
 
-        if (warnings.isNotEmpty()) addField("", "**__Strikes__**")
+        if (strikes.isNotEmpty()) addField("", "**__Strikes__**")
         strikes.forEachIndexed { index, infraction ->
             addField(
                     "ID :: $index :: Weight :: ${infraction.points}",

--- a/src/main/kotlin/me/ddivad/judgebot/embeds/UserEmbeds.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/embeds/UserEmbeds.kt
@@ -44,20 +44,15 @@ suspend fun MenuBuilder.createHistoryEmbed(
             url = target.asUser().avatar.url
         }
         val memberInGuild = target.asMemberOrNull(guild.id)
+        addInlineField("Notes", "${notes.size}")
+        addInlineField("Infractions", "${infractions.size}")
+        addInlineField("Points", "**${member.getPoints(guild)} / $maxPoints**")
+        addInlineField("History Invokes", "${userGuildDetails.historyCount}")
+        addInlineField("Creation date", formatOffsetTime(target.id.timeStamp))
         if (memberInGuild != null) {
-            addInlineField("Notes", "${notes.size}")
-            addInlineField("Infractions", "${infractions.size}")
-            addInlineField("Points", "**${member.getPoints(guild)} / $maxPoints**")
             addInlineField("Join date", formatOffsetTime(memberInGuild.joinedAt))
-            addInlineField("Creation date", formatOffsetTime(target.id.timeStamp))
-            addInlineField("History Invokes", "${userGuildDetails.historyCount}")
         } else {
-            addField("**__User not currently in this guild__**", "")
-            addInlineField("Notes", "${notes.size}")
-            addInlineField("Infractions", "${infractions.size}")
-            addInlineField("Points", "**${member.getPoints(guild)} / $maxPoints**")
-            addInlineField("Creation date", formatOffsetTime(target.id.timeStamp))
-            addInlineField("History Invokes", "${userGuildDetails.historyCount}")
+            addField("Status", "```User is not in this guild```")
         }
 
         val currentPunishments = databaseService.guilds.getPunishmentsForUser(guild, target.asUser())

--- a/src/main/kotlin/me/ddivad/judgebot/services/LoggingService.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/services/LoggingService.kt
@@ -63,10 +63,13 @@ class LoggingService(private val configuration: Configuration) {
             log(guild, "**Info ::** User ${user.mention} banned for not changing their avatar")
 
     suspend fun initialiseMutes(guild: Guild, role: Role) =
-            log(guild, "**Info ::** Existing mute timers initialized using ${role.mention} :: ${role.id}")
+            log(guild, "**Info ::** Existing mute timers initialized using ${role.mention} :: ${role.id.value}")
 
     suspend fun initialiseBans(guild: Guild) =
             log(guild, "**Info ::** Existing ban timers initialized.")
+
+    suspend fun dmDisabled(guild: Guild, target: User) =
+        log(guild, "**Error ::** Attempted to send direct message to ${target.mention} :: ${target.id} but they have DMs disabled")
 
     private suspend fun log(guild: Guild, message: String) = getLoggingChannel(guild)?.createMessage(message)
 

--- a/src/main/kotlin/me/ddivad/judgebot/services/infractions/BadPfpService.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/services/infractions/BadPfpService.kt
@@ -1,5 +1,6 @@
 package me.ddivad.judgebot.services.infractions
 
+import com.gitlab.kordlib.common.exception.RequestException
 import com.gitlab.kordlib.core.behavior.ban
 import com.gitlab.kordlib.core.entity.Guild
 import com.gitlab.kordlib.core.entity.Member
@@ -8,6 +9,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import me.ddivad.judgebot.embeds.createBadPfpEmbed
+import me.ddivad.judgebot.embeds.createUnmuteEmbed
 import me.ddivad.judgebot.services.LoggingService
 import me.jakejmattson.discordkt.api.Discord
 import me.jakejmattson.discordkt.api.annotations.Service
@@ -21,8 +23,12 @@ class BadPfpService(private val muteService: MuteService,
     private suspend fun toKey(member: Member): Pair<GuildID, UserId> = member.guild.id.value to member.asUser().id.value
 
     suspend fun applyBadPfp(target: Member, guild: Guild, timeLimit: Long) {
-        target.sendPrivateMessage {
-            createBadPfpEmbed(guild, target)
+        try {
+            target.sendPrivateMessage {
+                createBadPfpEmbed(guild, target)
+            }
+        } catch (ex: RequestException) {
+            loggingService.dmDisabled(guild, target.asUser())
         }
         muteService.applyMute(target, timeLimit, "Bad Pfp Mute")
         loggingService.badBfpApplied(guild, target)

--- a/src/main/kotlin/me/ddivad/judgebot/services/infractions/BanService.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/services/infractions/BanService.kt
@@ -24,7 +24,7 @@ class BanService(private val databaseService: DatabaseService,
     private val banTracker = hashMapOf<Pair<UserId, GuildID>, Job>()
     private fun toKey(user: User, guild: Guild): Pair<GuildID, UserId> = user.id.value to guild.id.value
 
-    suspend fun banUser(target: Member, guild: Guild, punishment: Punishment, deleteDays: Int = 1) {
+    suspend fun banUser(target: User, guild: Guild, punishment: Punishment, deleteDays: Int = 1) {
         guild.ban(target.id) {
             deleteMessagesDays = deleteDays
             reason = punishment.reason
@@ -32,7 +32,7 @@ class BanService(private val databaseService: DatabaseService,
         databaseService.guilds.addBan(guild, Ban(target.id.value, punishment.moderator, punishment.reason))
         if (punishment.clearTime != null) {
             databaseService.guilds.addPunishment(guild.asGuild(), punishment)
-            val key = toKey(target.asUser(), guild)
+            val key = toKey(target, guild)
             banTracker[key] = GlobalScope.launch {
                 delay(punishment.clearTime)
                 guild.unban(target.id)

--- a/src/main/kotlin/me/ddivad/judgebot/services/infractions/MuteService.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/services/infractions/MuteService.kt
@@ -67,8 +67,12 @@ class MuteService(val configuration: Configuration,
             removeMute(guild, user)
         }.also {
             loggingService.roleApplied(guild, member.asUser(), muteRole)
-            member.sendPrivateMessage {
-                createMuteEmbed(guild, member, reason, time)
+            try {
+                member.sendPrivateMessage {
+                    createMuteEmbed(guild, member, reason, time)
+                }
+            } catch (ex: RequestException) {
+                loggingService.dmDisabled(guild, user)
             }
         }
     }
@@ -83,8 +87,12 @@ class MuteService(val configuration: Configuration,
             val key = toKey(user, guild)
             guild.getMemberOrNull(user.id)?.let {
                 it.removeRole(muteRole.id)
-                it.sendPrivateMessage {
-                    createUnmuteEmbed(guild, user)
+                try {
+                    it.sendPrivateMessage {
+                        createUnmuteEmbed(guild, user)
+                    }
+                } catch (ex: RequestException) {
+                    loggingService.dmDisabled(guild, user)
                 }
                 loggingService.roleRemoved(guild, user, muteRole)
                 if (checkRoleState(guild, it) == RoleState.Untracked) return@runBlocking

--- a/src/main/kotlin/me/ddivad/judgebot/util/NumberUtils.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/util/NumberUtils.kt
@@ -4,6 +4,12 @@ import org.joda.time.DateTime
 import org.joda.time.Days
 import org.joda.time.Hours
 import org.joda.time.Minutes
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+import java.util.*
+import java.util.concurrent.TimeUnit
 
 fun timeToString(milliseconds: Long): String {
     val seconds = (milliseconds / 1000) % 60
@@ -27,5 +33,16 @@ fun timeBetween(endTime: DateTime): String {
         days > 0 -> "$days days"
         hours > 0 -> "$hours hours"
         else -> "$minutes minutes"
+    }
+}
+
+fun formatOffsetTime(time: Instant): String {
+    val days = TimeUnit.MILLISECONDS.toDays(DateTime.now().millis - time.toEpochMilli())
+    val formatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT).withLocale(Locale.UK).withZone(ZoneOffset.UTC)
+    return if (days > 4) {
+        "${formatter.format(time)}\n($days days ago)"
+    } else {
+        val hours = TimeUnit.MILLISECONDS.toHours(DateTime.now().millis - time.toEpochMilli())
+        "${formatter.format(time)}\n($hours hours ago)"
     }
 }


### PR DESCRIPTION
# feat: history embed improvements, general fixes

- Added LowerUserArg to fix issue banning members that have left.
- Added open DM check before sending info.
- Updated handling and logging of cases where users have DMs disabled.
- Updated history embed.
  - Refactored each page into its own method.
  - Added colour coding to the history embed based on status.
  - Added status information for more cases than before.
  - General cleanup.
- Removed status command (was never really used).