### PR TITLE
fix: gag reaction check if a user is already muted

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -23,8 +23,8 @@
 | badpfp           | (cancel), LowerMemberArg         | Notifies the user that they should change their profile pic and applies a 30 minute mute. Bans the user if they don't change picture. |
 | cleanse          | LowerMemberArg                   | Use this to delete (permanently) as user's infractions.                                                                               |
 | removeInfraction | LowerMemberArg, Infraction ID    | Use this to delete (permanently) an infraction from a user.                                                                           |
-| strike, s        | LowerMemberArg, (Weight), Reason | Strike a user.                                                                                                                        |
-| warn, w          | LowerMemberArg, Reason           | Warn a user.                                                                                                                          |
+| strike, s, S     | LowerMemberArg, (Weight), Reason | Strike a user.                                                                                                                        |
+| warn, w, W       | LowerMemberArg, Reason           | Warn a user.                                                                                                                          |
 
 ## Mute
 | Commands | Arguments                    | Description                                             |
@@ -51,15 +51,15 @@
 | rules       | (Message) | List the rules of this guild. Pass a message ID to edit existing rules embed.                     |
 
 ## User
-| Commands     | Arguments                                 | Description                                                |
-| ------------ | ----------------------------------------- | ---------------------------------------------------------- |
-| ban          | LowerUserArg, (Delete message days), Text | Ban a member from this guild.                              |
-| getBanReason | User                                      | Get a ban reason for a banned user                         |
-| history, h   | User                                      | Use this to view a user's record.                          |
-| selfHistory  |                                           | View your infraction history (contents will be DM'd)       |
-| setBanReason | User, Reason                              | Set a ban reason for a banned user                         |
-| unban        | User                                      | Unban a banned member from this guild.                     |
-| whatpfp      | User                                      | Perform a reverse image search of a User's profile picture |
+| Commands      | Arguments                                 | Description                                                |
+| ------------- | ----------------------------------------- | ---------------------------------------------------------- |
+| ban           | LowerUserArg, (Delete message days), Text | Ban a member from this guild.                              |
+| getBanReason  | User                                      | Get a ban reason for a banned user                         |
+| history, h, H | User                                      | Use this to view a user's record.                          |
+| selfHistory   |                                           | View your infraction history (contents will be DM'd)       |
+| setBanReason  | User, Reason                              | Set a ban reason for a banned user                         |
+| unban         | User                                      | Unban a banned member from this guild.                     |
+| whatpfp       | User                                      | Perform a reverse image search of a User's profile picture |
 
 ## Utility
 | Commands | Arguments | Description          |

--- a/src/main/kotlin/me/ddivad/judgebot/listeners/StaffReactionListeners.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/listeners/StaffReactionListeners.kt
@@ -12,6 +12,7 @@ import me.ddivad.judgebot.services.DatabaseService
 import me.ddivad.judgebot.services.PermissionLevel
 import me.ddivad.judgebot.services.PermissionsService
 import me.ddivad.judgebot.services.infractions.MuteService
+import me.ddivad.judgebot.services.infractions.RoleState
 import me.jakejmattson.discordkt.api.dsl.listeners
 import me.jakejmattson.discordkt.api.extensions.isSelf
 import me.jakejmattson.discordkt.api.extensions.sendPrivateMessage
@@ -32,8 +33,13 @@ fun onStaffReactionAdd(muteService: MuteService,
         if (permissionsService.hasPermission(member, PermissionLevel.Moderator) && !member.isHigherRankedThan(permissionsService, messageAuthor)) {
             when (this.emoji.name) {
                 guildConfiguration.reactions.gagReaction -> {
+                    val target = messageAuthor.asMember(guild.id)
                     msg.deleteReaction(this.emoji)
-                    muteService.gag(messageAuthor.asMember(guild.id))
+                    if (muteService.checkRoleState(guild, target) == RoleState.Tracked) {
+                        member.sendPrivateMessage("${messageAuthor.mention} is already muted.")
+                        return@on
+                    }
+                    muteService.gag(target)
                     member.sendPrivateMessage("${messageAuthor.mention} gagged.")
                 }
                 guildConfiguration.reactions.historyReaction -> {

--- a/src/main/kotlin/me/ddivad/judgebot/services/infractions/MuteService.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/services/infractions/MuteService.kt
@@ -44,8 +44,10 @@ class MuteService(val configuration: Configuration,
     suspend fun initGuilds() {
         configuration.guildConfigurations.forEach { config ->
             val guild = config.value.id.toSnowflake().let { discord.api.getGuild(it) } ?: return@forEach
-            initialiseMuteTimers(guild)
-            setupMutedRole(guild)
+            runBlocking {
+                initialiseMuteTimers(guild)
+                setupMutedRole(guild)
+            }
         }
     }
 
@@ -115,8 +117,8 @@ class MuteService(val configuration: Configuration,
                     removeMute(guild, user)
                 }
             }
-            loggingService.initialiseMutes(guild, getMutedRole(guild))
         }
+        loggingService.initialiseMutes(guild, getMutedRole(guild))
     }
 
     suspend fun handleRejoinMute(guild: Guild, member: Member) {


### PR DESCRIPTION
# fix: gag reaction check if a user is already muted

Fix the gag reaction being able to override mutes that are longer than a gag.