### PR TITLE
feat: updates for join leave refactor & migration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ repositories {
 
 dependencies {
     implementation("me.jakejmattson:DiscordKt:${Versions.DISCORDKT}")
-    implementation("org.litote.kmongo:kmongo-coroutine:4.1.3")
+    implementation("org.litote.kmongo:kmongo-coroutine:4.2.6")
     implementation("joda-time:joda-time:2.10.6")
 }
 

--- a/commands.md
+++ b/commands.md
@@ -5,11 +5,12 @@
 | ----------- | ------------------------------ |
 | (Argument)  | Argument is not required.      |
 
-## Configuration
-| Commands      | Arguments     | Description                                                    |
-| ------------- | ------------- | -------------------------------------------------------------- |
-| configuration | (GuildConfig) | Update configuration parameters for this guild (conversation). |
-| setup         |               | Configure a guild to use Judgebot.                             |
+## Guild
+| Commands          | Arguments     | Description                                                    |
+| ----------------- | ------------- | -------------------------------------------------------------- |
+| activePunishments |               | View active punishments for a guild.                           |
+| configuration     | (GuildConfig) | Update configuration parameters for this guild (conversation). |
+| setup             |               | Configure a guild to use Judgebot.                             |
 
 ## Information
 | Commands   | Arguments                    | Description                                         |
@@ -21,8 +22,8 @@
 | Commands         | Arguments                        | Description                                                                                                                           |
 | ---------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
 | badpfp           | (cancel), LowerMemberArg         | Notifies the user that they should change their profile pic and applies a 30 minute mute. Bans the user if they don't change picture. |
-| cleanse          | LowerMemberArg                   | Use this to delete (permanently) as user's infractions.                                                                               |
-| removeInfraction | LowerMemberArg, Infraction ID    | Use this to delete (permanently) an infraction from a user.                                                                           |
+| cleanse          | LowerUserArg                     | Use this to delete (permanently) as user's infractions.                                                                               |
+| removeInfraction | LowerUserArg, Infraction ID      | Use this to delete (permanently) an infraction from a user.                                                                           |
 | strike, s, S     | LowerMemberArg, (Weight), Reason | Strike a user.                                                                                                                        |
 | warn, w, W       | LowerMemberArg, Reason           | Warn a user.                                                                                                                          |
 

--- a/src/main/kotlin/me/ddivad/judgebot/Main.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/Main.kt
@@ -4,10 +4,10 @@ import com.gitlab.kordlib.gateway.Intent
 import com.gitlab.kordlib.gateway.PrivilegedIntent
 import me.ddivad.judgebot.dataclasses.Configuration
 import me.ddivad.judgebot.services.BotStatsService
-import me.ddivad.judgebot.services.LoggingService
 import me.ddivad.judgebot.services.infractions.MuteService
 import me.ddivad.judgebot.services.PermissionsService
 import me.ddivad.judgebot.services.infractions.BanService
+import me.ddivad.judgebot.services.migrations.JoinLeaveMigration
 import me.ddivad.judgebot.services.requiredPermissionLevel
 import me.jakejmattson.discordkt.api.dsl.bot
 import me.jakejmattson.discordkt.api.extensions.addInlineField
@@ -58,7 +58,7 @@ suspend fun main(args: Array<String>) {
             field {
                 name = "Build Info"
                 value = "```" +
-                        "Version:   1.8.2\n" +
+                        "Version:   2.0.0\n" +
                         "DiscordKt: ${versions.library}\n" +
                         "Kotlin:    $kotlinVersion" +
                         "```"
@@ -83,9 +83,14 @@ suspend fun main(args: Array<String>) {
         }
 
         onStart {
-            val (muteService, banService, loggingService) = this.getInjectionObjects(MuteService::class, BanService::class, LoggingService::class)
+            val (muteService, banService, joinLeaveMigration) = this.getInjectionObjects(
+                MuteService::class,
+                BanService::class,
+                JoinLeaveMigration::class
+            )
             muteService.initGuilds()
             banService.initialiseBanTimers()
+            joinLeaveMigration.run()
         }
 
         intents {

--- a/src/main/kotlin/me/ddivad/judgebot/arguments/LowerMemberArg.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/arguments/LowerMemberArg.kt
@@ -31,4 +31,3 @@ open class LowerMemberArg(override val name: String = "LowerMemberArg") : Argume
 
 suspend fun Member.isHigherRankedThan(permissions: PermissionsService, targetMember: Member) =
         permissions.getPermissionRank(this) < permissions.getPermissionRank(targetMember)
-

--- a/src/main/kotlin/me/ddivad/judgebot/commands/GuildCommands.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/commands/GuildCommands.kt
@@ -4,6 +4,7 @@ import me.ddivad.judgebot.arguments.GuildConfigArg
 import me.ddivad.judgebot.conversations.guild.GuildSetupConversation
 import me.ddivad.judgebot.conversations.guild.EditConfigConversation
 import me.ddivad.judgebot.dataclasses.Configuration
+import me.ddivad.judgebot.embeds.createActivePunishmentsEmbed
 import me.ddivad.judgebot.services.DatabaseService
 import me.ddivad.judgebot.services.infractions.MuteService
 import me.ddivad.judgebot.services.PermissionLevel
@@ -12,7 +13,7 @@ import me.jakejmattson.discordkt.api.dsl.commands
 
 fun guildConfigCommands(configuration: Configuration,
                         databaseService: DatabaseService,
-                        muteService: MuteService) = commands("Configuration") {
+                        muteService: MuteService) = commands("Guild") {
     guildCommand("setup") {
         description = "Configure a guild to use Judgebot."
         requiredPermissionLevel = PermissionLevel.Administrator
@@ -40,6 +41,19 @@ fun guildConfigCommands(configuration: Configuration,
             EditConfigConversation(configuration)
                     .createEditConfigurationConversation(guild, args.first)
                     .startPublicly(discord, author, channel)
+        }
+    }
+
+    guildCommand("activePunishments") {
+        description = "View active punishments for a guild."
+        requiredPermissionLevel = PermissionLevel.Staff
+        execute {
+            val punishments = databaseService.guilds.getActivePunishments(guild)
+            if (punishments.isEmpty()) {
+                respond("No active punishments found.")
+                return@execute
+            }
+            respond { createActivePunishmentsEmbed(guild, punishments) }
         }
     }
 }

--- a/src/main/kotlin/me/ddivad/judgebot/commands/UserCommands.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/commands/UserCommands.kt
@@ -34,7 +34,7 @@ fun createUserCommands(databaseService: DatabaseService,
         }
     }
 
-    guildCommand("listAlts", "alts") {
+    guildCommand("alts") {
         description = "Use this to view a user's alt accounts."
         requiredPermissionLevel = PermissionLevel.Moderator
         execute(UserArg) {

--- a/src/main/kotlin/me/ddivad/judgebot/dataclasses/Configuration.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/dataclasses/Configuration.kt
@@ -5,25 +5,33 @@ import com.gitlab.kordlib.core.entity.Role
 import me.jakejmattson.discordkt.api.dsl.Data
 
 data class Configuration(
-        val ownerId: String = "insert-owner-id",
-        var prefix: String = "judge!",
-        val guildConfigurations: MutableMap<Long, GuildConfiguration> = mutableMapOf(),
-        val dbConfiguration: DatabaseConfiguration = DatabaseConfiguration()
+    val ownerId: String = "insert-owner-id",
+    var prefix: String = "judge!",
+    val guildConfigurations: MutableMap<Long, GuildConfiguration> = mutableMapOf(),
+    val dbConfiguration: DatabaseConfiguration = DatabaseConfiguration()
 ) : Data("config/config.json") {
     operator fun get(id: Long) = guildConfigurations[id]
     fun hasGuildConfig(guildId: Long) = guildConfigurations.containsKey(guildId)
 
-    fun setup(guild: Guild, prefix: String, adminRole: Role, staffRole: Role, moderatorRole: Role, mutedRole: Role, logging: LoggingConfiguration) {
+    fun setup(
+        guild: Guild,
+        prefix: String,
+        adminRole: Role,
+        staffRole: Role,
+        moderatorRole: Role,
+        mutedRole: Role,
+        logging: LoggingConfiguration
+    ) {
         if (guildConfigurations[guild.id.longValue] != null) return
 
         val newConfiguration = GuildConfiguration(
-                guild.id.value,
-                prefix,
-                mutableListOf(moderatorRole.id.value),
-                mutableListOf(staffRole.id.value),
-                mutableListOf(adminRole.id.value),
-                mutedRole.id.value,
-                logging
+            guild.id.value,
+            prefix,
+            mutableListOf(moderatorRole.id.value),
+            mutableListOf(staffRole.id.value),
+            mutableListOf(adminRole.id.value),
+            mutedRole.id.value,
+            logging
         )
 
         // Setup default punishments
@@ -41,48 +49,48 @@ data class Configuration(
 }
 
 data class DatabaseConfiguration(
-            val address: String = "mongodb://localhost:27017",
-        val databaseName: String = "judgebot"
+    val address: String = "mongodb://localhost:27017",
+    val databaseName: String = "judgebot"
 )
 
 data class GuildConfiguration(
-        val id: String = "",
-        var prefix: String = "j!",
-        var moderatorRoles: MutableList<String> = mutableListOf(),
-        var staffRoles: MutableList<String> = mutableListOf(),
-        var adminRoles: MutableList<String> = mutableListOf(),
-        var mutedRole: String = "",
-        var loggingConfiguration: LoggingConfiguration = LoggingConfiguration(),
-        var infractionConfiguration: InfractionConfiguration = InfractionConfiguration(),
-        var punishments: MutableList<PunishmentLevel> = mutableListOf(),
-        var reactions: ReactionConfiguration = ReactionConfiguration()
+    val id: String = "",
+    var prefix: String = "j!",
+    var moderatorRoles: MutableList<String> = mutableListOf(),
+    var staffRoles: MutableList<String> = mutableListOf(),
+    var adminRoles: MutableList<String> = mutableListOf(),
+    var mutedRole: String = "",
+    var loggingConfiguration: LoggingConfiguration = LoggingConfiguration(),
+    var infractionConfiguration: InfractionConfiguration = InfractionConfiguration(),
+    var punishments: MutableList<PunishmentLevel> = mutableListOf(),
+    var reactions: ReactionConfiguration = ReactionConfiguration()
 )
 
 data class LoggingConfiguration(
-        var alertChannel: String = "",
-        var loggingChannel: String = "insert_id",
-        var logRoles: Boolean = true,
-        var logInfractions: Boolean = true,
-        var logPunishments: Boolean = true
+    var alertChannel: String = "",
+    var loggingChannel: String = "insert_id",
+    var logRoles: Boolean = true,
+    var logInfractions: Boolean = true,
+    var logPunishments: Boolean = true
 )
 
 data class InfractionConfiguration(
-        var pointCeiling: Int = 50,
-        var strikePoints: Int = 10,
-        var warnPoints: Int = 0,
-        var pointDecayPerWeek: Int = 2,
+    var pointCeiling: Int = 50,
+    var strikePoints: Int = 10,
+    var warnPoints: Int = 0,
+    var pointDecayPerWeek: Int = 2,
 )
 
 data class PunishmentLevel(
-        var points: Int = 0,
-        var punishment: PunishmentType,
-        var duration: Long? = null
+    var points: Int = 0,
+    var punishment: PunishmentType,
+    var duration: Long? = null
 )
 
 data class ReactionConfiguration(
-        var enabled: Boolean = true,
-        var gagReaction: String = "",
-        var historyReaction: String = "",
-        var deleteMessageReaction: String = "",
-        var flagMessageReaction: String = ""
+    var enabled: Boolean = true,
+    var gagReaction: String = "",
+    var historyReaction: String = "",
+    var deleteMessageReaction: String = "",
+    var flagMessageReaction: String = ""
 )

--- a/src/main/kotlin/me/ddivad/judgebot/dataclasses/GuildInformation.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/dataclasses/GuildInformation.kt
@@ -1,11 +1,11 @@
 package me.ddivad.judgebot.dataclasses
 
 data class GuildInformation(
-        val guildId: String,
-        val guildName: String,
-        val rules: MutableList<Rule> = mutableListOf(),
-        val bans: MutableList<Ban> = mutableListOf(),
-        val punishments: MutableList<Punishment> = mutableListOf()
+    val guildId: String,
+    val guildName: String,
+    val rules: MutableList<Rule> = mutableListOf(),
+    val bans: MutableList<Ban> = mutableListOf(),
+    val punishments: MutableList<Punishment> = mutableListOf()
 ) {
     fun addRule(rule: Rule): GuildInformation = this.apply {
         this.rules.add(rule)
@@ -55,9 +55,9 @@ data class GuildInformation(
 }
 
 data class Rule(
-        val number: Int,
-        val title: String,
-        val description: String,
-        val link: String,
-        var archived: Boolean = false
+    val number: Int,
+    val title: String,
+    val description: String,
+    val link: String,
+    var archived: Boolean = false
 )

--- a/src/main/kotlin/me/ddivad/judgebot/dataclasses/GuildMember.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/dataclasses/GuildMember.kt
@@ -4,28 +4,28 @@ import com.gitlab.kordlib.core.entity.Guild
 import org.joda.time.DateTime
 import org.joda.time.Weeks
 
+data class GuildLeave(
+    val joinDate: Long,
+    var leaveDate: Long?
+)
+
 data class GuildMemberDetails(
-        val guildId: String,
-        val notes: MutableList<Note> = mutableListOf(),
-        val infractions: MutableList<Infraction> = mutableListOf(),
-        val info: MutableList<Info> = mutableListOf(),
-        val leaveHistory: MutableList<GuildLeave> = mutableListOf(),
-        val linkedAccounts: MutableList<String> = mutableListOf(),
-        var historyCount: Int = 0,
-        var points: Int = 0,
-        var pointDecayTimer: Long = DateTime().millis,
-        var lastInfraction: Long = 0,
-        val deletedMessageCount: DeletedMessages = DeletedMessages()
+    val guildId: String,
+    val notes: MutableList<Note> = mutableListOf(),
+    val infractions: MutableList<Infraction> = mutableListOf(),
+    val info: MutableList<Info> = mutableListOf(),
+    val linkedAccounts: MutableList<String> = mutableListOf(),
+    var leaveHistory: MutableList<GuildLeave> = mutableListOf(),
+    var historyCount: Int = 0,
+    var points: Int = 0,
+    var pointDecayTimer: Long = DateTime().millis,
+    var lastInfraction: Long = 0,
+    val deletedMessageCount: DeletedMessages = DeletedMessages()
 )
 
 data class DeletedMessages(
     var deleteReaction: Int = 0,
     var total: Int = 0
-)
-
-data class GuildLeave(
-        val joinDate: Long?,
-        var leaveDate: Long?
 )
 
 data class GuildMember(
@@ -101,16 +101,6 @@ data class GuildMember(
 
     fun incrementHistoryCount(guildId: String) {
         this.getGuildInfo(guildId).historyCount += 1
-    }
-
-    fun addGuildLeave( guild: Guild, leaveDate: Long) = with(this.getGuildInfo(guild.id.value)) {
-        this.leaveHistory.find { it.joinDate != null && it.leaveDate == null }?.let {
-            it.leaveDate = leaveDate
-        }
-    }
-
-    fun addGuildJoinDate(guild: Guild, joinDate: Long) = with(this.getGuildInfo(guild.id.value)){
-        this.leaveHistory.add(GuildLeave(joinDate, null))
     }
 
     fun addMessageDeleted(guild: Guild, deleteReaction: Boolean) = with(this.getGuildInfo(guild.id.value)) {

--- a/src/main/kotlin/me/ddivad/judgebot/dataclasses/JoinLeave.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/dataclasses/JoinLeave.kt
@@ -1,0 +1,8 @@
+package me.ddivad.judgebot.dataclasses
+
+data class JoinLeave(
+    val guildId: String,
+    val userId: String,
+    val joinDate: Long,
+    var leaveDate: Long? = null
+)

--- a/src/main/kotlin/me/ddivad/judgebot/dataclasses/Note.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/dataclasses/Note.kt
@@ -6,9 +6,12 @@ data class Note(
     var note: String,
     var moderator: String,
     val dateTime: Long,
-    val id: Int)
+    val id: Int
+)
 
-data class Info(val message: String,
-                val moderator: String,
-                val dateTime: Long = DateTime().millis,
-                var id: Int? = null)
+data class Info(
+    val message: String,
+    val moderator: String,
+    val dateTime: Long = DateTime().millis,
+    var id: Int? = null
+)

--- a/src/main/kotlin/me/ddivad/judgebot/dataclasses/Punishment.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/dataclasses/Punishment.kt
@@ -1,15 +1,19 @@
 package me.ddivad.judgebot.dataclasses
 
-data class Punishment(val userId: String,
-                      val type: InfractionType,
-                      var reason: String,
-                      var moderator: String,
-                      val clearTime: Long? = null,
-                      var id: Int = 0)
+data class Punishment(
+    val userId: String,
+    val type: InfractionType,
+    var reason: String,
+    var moderator: String,
+    val clearTime: Long? = null,
+    var id: Int = 0
+)
 
-data class Ban(val userId: String,
-               val moderator: String,
-               var reason: String)
+data class Ban(
+    val userId: String,
+    val moderator: String,
+    var reason: String
+)
 
 enum class PunishmentType {
     MUTE, BAN, NONE

--- a/src/main/kotlin/me/ddivad/judgebot/embeds/GuildEmbeds.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/embeds/GuildEmbeds.kt
@@ -1,12 +1,17 @@
 package me.ddivad.judgebot.embeds
 
+import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.core.entity.Guild
 import com.gitlab.kordlib.rest.Image
 import com.gitlab.kordlib.rest.builder.message.EmbedBuilder
 import me.ddivad.judgebot.arguments.validConfigParameters
 import me.ddivad.judgebot.dataclasses.GuildConfiguration
+import me.ddivad.judgebot.dataclasses.Punishment
+import me.ddivad.judgebot.util.timeBetween
 import me.ddivad.judgebot.util.timeToString
+import me.jakejmattson.discordkt.api.extensions.addField
 import me.jakejmattson.discordkt.api.extensions.toSnowflake
+import org.joda.time.DateTime
 import java.awt.Color
 
 suspend fun EmbedBuilder.createConfigEmbed(config: GuildConfiguration, guild: Guild) {
@@ -68,6 +73,22 @@ fun EmbedBuilder.createConfigOptionsEmbed(config: GuildConfiguration, guild: Gui
     field {
         name = "Usage: `${config.prefix}configuration <option>`"
         value = "```css\n${validConfigParameters.joinToString("\n")}\n```"
+    }
+    footer {
+        icon = guild.getIconUrl(Image.Format.PNG) ?: ""
+        text = guild.name
+    }
+}
+
+suspend fun EmbedBuilder.createActivePunishmentsEmbed(guild: Guild, punishments: List<Punishment>) {
+    title = "__Active Punishments__"
+    color = Color.MAGENTA
+    punishments.forEach {
+        val user = guild.kord.getUser(Snowflake(it.userId))?.mention
+        addField(
+            "${it.id} - ${it.type} - ${timeBetween(DateTime(it.clearTime))} left.",
+            "User: $user"
+        )
     }
     footer {
         icon = guild.getIconUrl(Image.Format.PNG) ?: ""

--- a/src/main/kotlin/me/ddivad/judgebot/listeners/MemberReactionListeners.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/listeners/MemberReactionListeners.kt
@@ -20,13 +20,17 @@ fun onMemberReactionAdd(configuration: Configuration) = listeners {
         when (this.emoji.name) {
             guildConfiguration.reactions.flagMessageReaction -> {
                 message.deleteReaction(this.emoji)
-                guild.asGuild().getChannelOf<TextChannel>(guildConfiguration.loggingConfiguration.alertChannel.toSnowflake()).asChannel()
-                        .createMessage("**Message Flagged**" +
+                guild.asGuild()
+                    .getChannelOf<TextChannel>(guildConfiguration.loggingConfiguration.alertChannel.toSnowflake())
+                    .asChannel()
+                    .createMessage(
+                        "**Message Flagged**" +
                                 "\n**User**: ${user.mention}" +
                                 "\n**Channel**: ${message.channel.mention}" +
                                 "\n**Author:** ${message.asMessage().author?.mention}" +
-                                "\n**Message:** ${message.asMessage().jumpLink(guild.id.value)}")
-                        .addReaction(Emojis.question)
+                                "\n**Message:** ${message.asMessage().jumpLink(guild.id.value)}"
+                    )
+                    .addReaction(Emojis.question)
             }
         }
     }

--- a/src/main/kotlin/me/ddivad/judgebot/listeners/NewChannelOverrideListener.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/listeners/NewChannelOverrideListener.kt
@@ -19,9 +19,10 @@ fun onChannelCreated(configuration: Configuration, loggingService: LoggingServic
         val deniedPermissions = channel.getPermissionOverwritesForRole(mutedRole.id)?.denied ?: Permissions()
         if (!deniedPermissions.contains(Permission.SendMessages) || !deniedPermissions.contains(Permission.AddReactions)) {
             channel.addOverwrite(
-                    PermissionOverwrite.forRole(
-                            mutedRole.id,
-                            denied = deniedPermissions.plus(Permission.SendMessages).plus(Permission.AddReactions))
+                PermissionOverwrite.forRole(
+                    mutedRole.id,
+                    denied = deniedPermissions.plus(Permission.SendMessages).plus(Permission.AddReactions)
+                )
             )
             loggingService.channelOverrideAdded(guild, channel)
         }

--- a/src/main/kotlin/me/ddivad/judgebot/listeners/StaffReactionListeners.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/listeners/StaffReactionListeners.kt
@@ -18,10 +18,12 @@ import me.jakejmattson.discordkt.api.extensions.isSelf
 import me.jakejmattson.discordkt.api.extensions.sendPrivateMessage
 
 @Suppress("unused")
-fun onStaffReactionAdd(muteService: MuteService,
-                       databaseService: DatabaseService,
-                       permissionsService: PermissionsService,
-                       configuration: Configuration) = listeners {
+fun onStaffReactionAdd(
+    muteService: MuteService,
+    databaseService: DatabaseService,
+    permissionsService: PermissionsService,
+    configuration: Configuration
+) = listeners {
     on<ReactionAddEvent> {
         val guild = guild?.asGuildOrNull() ?: return@on
         val guildConfiguration = configuration[guild.asGuild().id.longValue]
@@ -31,7 +33,11 @@ fun onStaffReactionAdd(muteService: MuteService,
         val msg = message.asMessage()
         val target = databaseService.users.getOrCreateUser(messageAuthor, guild.asGuild())
 
-        if (permissionsService.hasPermission(staffMember, PermissionLevel.Moderator) && !staffMember.isHigherRankedThan(permissionsService, messageAuthor)) {
+        if (permissionsService.hasPermission(staffMember, PermissionLevel.Moderator) && !staffMember.isHigherRankedThan(
+                permissionsService,
+                messageAuthor
+            )
+        ) {
             when (this.emoji.name) {
                 guildConfiguration.reactions.gagReaction -> {
                     msg.deleteReaction(this.emoji)
@@ -44,7 +50,14 @@ fun onStaffReactionAdd(muteService: MuteService,
                 }
                 guildConfiguration.reactions.historyReaction -> {
                     msg.deleteReaction(this.emoji)
-                    staffMember.sendPrivateMessage { createCondensedHistoryEmbed(messageAuthor, target, guild.asGuild(), configuration) }
+                    staffMember.sendPrivateMessage {
+                        createCondensedHistoryEmbed(
+                            messageAuthor,
+                            target,
+                            guild.asGuild(),
+                            configuration
+                        )
+                    }
                 }
                 guildConfiguration.reactions.deleteMessageReaction -> {
                     msg.deleteReaction(this.emoji)
@@ -55,8 +68,10 @@ fun onStaffReactionAdd(muteService: MuteService,
                             createMessageDeleteEmbed(guild, msg)
                         }
                     } catch (ex: RequestException) {
-                        staffMember.sendPrivateMessage("User ${messageAuthor.mention} has DM's disabled." +
-                                " Message deleted without notification.")
+                        staffMember.sendPrivateMessage(
+                            "User ${messageAuthor.mention} has DM's disabled." +
+                                    " Message deleted without notification."
+                        )
                     }
 
                 }

--- a/src/main/kotlin/me/ddivad/judgebot/services/DatabaseService.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/services/DatabaseService.kt
@@ -1,10 +1,14 @@
 package me.ddivad.judgebot.services
 
 import me.ddivad.judgebot.services.database.GuildOperations
+import me.ddivad.judgebot.services.database.JoinLeaveOperations
 import me.ddivad.judgebot.services.database.UserOperations
 import me.jakejmattson.discordkt.api.annotations.Service
 
 @Service
-open class DatabaseService(val users: UserOperations,
-                           val guilds: GuildOperations) {
+open class DatabaseService(
+    val users: UserOperations,
+    val guilds: GuildOperations,
+    val joinLeaves: JoinLeaveOperations
+) {
 }

--- a/src/main/kotlin/me/ddivad/judgebot/services/LoggingService.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/services/LoggingService.kt
@@ -13,7 +13,6 @@ import me.ddivad.judgebot.dataclasses.Punishment
 import me.ddivad.judgebot.services.infractions.RoleState
 import me.ddivad.judgebot.util.timeBetween
 import me.jakejmattson.discordkt.api.annotations.Service
-import me.jakejmattson.discordkt.api.extensions.toTimeString
 import org.joda.time.DateTime
 import java.text.SimpleDateFormat
 import java.util.*

--- a/src/main/kotlin/me/ddivad/judgebot/services/database/GuildOperations.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/services/database/GuildOperations.kt
@@ -102,6 +102,10 @@ class GuildOperations(connection: ConnectionService) {
         return this.getGuild(guild).punishments.filter { it.type == type }
     }
 
+    suspend fun getActivePunishments(guild: Guild): List<Punishment> {
+        return this.getGuild(guild).punishments
+    }
+
     private suspend fun getGuild(guild: Guild): GuildInformation {
         return guildCollection.findOne(GuildInformation::guildId eq guild.id.value)
                 ?: GuildInformation(guild.id.value, guild.name)

--- a/src/main/kotlin/me/ddivad/judgebot/services/database/JoinLeaveOperations.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/services/database/JoinLeaveOperations.kt
@@ -1,0 +1,39 @@
+package me.ddivad.judgebot.services.database
+
+import com.gitlab.kordlib.core.entity.Member
+import me.ddivad.judgebot.dataclasses.JoinLeave
+import me.jakejmattson.discordkt.api.annotations.Service
+import org.joda.time.DateTime
+import org.litote.kmongo.and
+import org.litote.kmongo.eq
+import org.litote.kmongo.setValue
+
+@Service
+class JoinLeaveOperations(connection: ConnectionService) {
+    private val joinLeaveCollection = connection.db.getCollection<JoinLeave>("JoinLeaves")
+
+    suspend fun createJoinLeaveRecord(guildId: String, target: Member) {
+        val joinLeave = JoinLeave(guildId, target.id.value, target.joinedAt.toEpochMilli())
+        joinLeaveCollection.insertOne(joinLeave)
+    }
+
+    suspend fun addLeaveData(guildId: String, userId: String) {
+        joinLeaveCollection.findOneAndUpdate(
+            and(
+                JoinLeave::guildId eq guildId,
+                JoinLeave::userId eq userId,
+                JoinLeave::leaveDate eq null
+            ),
+            setValue(JoinLeave::leaveDate, DateTime.now().millis)
+        )
+    }
+
+    suspend fun getMemberJoinLeaveDataForGuild(guildId: String, userId: String): List<JoinLeave> {
+        return joinLeaveCollection.find(
+            and(
+                JoinLeave::guildId eq guildId,
+                JoinLeave::userId eq userId,
+            )
+        ).toList()
+    }
+}

--- a/src/main/kotlin/me/ddivad/judgebot/services/database/UserOperations.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/services/database/UserOperations.kt
@@ -23,7 +23,6 @@ class UserOperations(connection: ConnectionService, private val configuration: C
         } else {
             val guildMember = GuildMember(target.id.value)
             guildMember.guilds.add(GuildMemberDetails(guild.id.value))
-            target.asMemberOrNull(guild.id)?.let { guildMember.addGuildJoinDate(guild, it.joinedAt.toEpochMilli()) }
             userCollection.insertOne(guildMember)
             guildMember
         }
@@ -63,10 +62,6 @@ class UserOperations(connection: ConnectionService, private val configuration: C
         return this.updateUser(user)
     }
 
-    fun getLinkedAccounts(guild: Guild, user: GuildMember) {
-        user.getLinkedAccounts(guild)
-    }
-
     suspend fun removeLinkedAccount(guild: Guild, user: GuildMember, userId: String): GuildMember {
         user.removeLinkedAccount(guild, userId)
         return this.updateUser(user)
@@ -101,16 +96,6 @@ class UserOperations(connection: ConnectionService, private val configuration: C
 
     suspend fun incrementUserHistory(user: GuildMember, guild: Guild): GuildMember {
         user.incrementHistoryCount(guild.id.value)
-        return this.updateUser(user)
-    }
-
-    suspend fun addGuildLeave(user: GuildMember, guild: Guild, leaveDateTime: Long): GuildMember {
-        user.addGuildLeave(guild, leaveDateTime)
-        return this.updateUser(user)
-    }
-
-    suspend fun addGuildJoin(guild: Guild, user: GuildMember, joinDateTime: Long): GuildMember {
-        user.addGuildJoinDate(guild, joinDateTime)
         return this.updateUser(user)
     }
 

--- a/src/main/kotlin/me/ddivad/judgebot/services/migrations/JoinLeaveMigration.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/services/migrations/JoinLeaveMigration.kt
@@ -1,0 +1,82 @@
+package me.ddivad.judgebot.services.migrations
+
+import me.ddivad.judgebot.dataclasses.GuildLeave
+import me.ddivad.judgebot.dataclasses.GuildMember
+import me.ddivad.judgebot.dataclasses.JoinLeave
+import me.ddivad.judgebot.services.database.ConnectionService
+import me.jakejmattson.discordkt.api.annotations.Service
+import org.litote.kmongo.`in`
+
+@Service
+class JoinLeaveMigration(connection: ConnectionService) {
+
+    private val userCollection = connection.db.getCollection<GuildMember>("Users")
+    private val joinLeaveCollection = connection.db.getCollection<JoinLeave>("JoinLeaves")
+
+    suspend fun run() {
+        println(
+            """
+                ---------------------------------
+                Migration Starting :: Join Leaves
+                ---------------------------------
+            """.trimIndent()
+        )
+
+        val users = getAllUsers()
+        val usersToDelete = getUsersToDelete(users)
+        println("Found ${users.size} users, ${usersToDelete.size} empty records.")
+        println("${users.size - usersToDelete.size} records will remain.")
+
+        migrateJoinLeaveData(users)
+
+        println("Deleting Empty Records...")
+        userCollection.deleteMany(GuildMember::userId `in` usersToDelete)
+        println("Empty records deleted.")
+        println(
+            """
+                ---------------------------------
+                Migration Complete :: Join Leaves
+                ---------------------------------
+            """.trimIndent()
+        )
+    }
+
+    private suspend fun getAllUsers(): List<GuildMember> {
+        return userCollection.find().toList()
+    }
+
+    private fun getUsersToDelete(allUsers: List<GuildMember>): MutableList<String> {
+        val idsToDelete = mutableListOf<String>()
+        allUsers.forEach { member ->
+            val emptyGuilds = member.guilds.filter { guild ->
+                guild.info.isEmpty() &&
+                        guild.infractions.isEmpty() &&
+                        guild.notes.isEmpty() &&
+                        guild.linkedAccounts.isEmpty() &&
+                        guild.deletedMessageCount.deleteReaction == 0
+            }
+            if (member.guilds.size == emptyGuilds.size) {
+                idsToDelete.add(member.userId)
+            }
+        }
+        return idsToDelete
+    }
+
+    private suspend fun migrateJoinLeaveData(users: List<GuildMember>) {
+        println("Migrating Join Leave Data...")
+        users.forEach { user ->
+            user.guilds.forEach { guild ->
+                addJoinLeaveData(guild.guildId, user.userId, guild.leaveHistory)
+                guild.leaveHistory.clear()
+            }
+        }
+        println("Join Leave Data migrated.")
+    }
+
+    private suspend fun addJoinLeaveData(guildId: String, memberId: String, joinLeaves: List<GuildLeave>) {
+        joinLeaves.forEach {
+            val newJoinLeave = JoinLeave(guildId, memberId, it.joinDate, it.leaveDate)
+            joinLeaveCollection.insertOne(newJoinLeave)
+        }
+    }
+}

--- a/src/main/kotlin/me/ddivad/judgebot/util/NumberUtils.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/util/NumberUtils.kt
@@ -30,9 +30,9 @@ fun timeBetween(endTime: DateTime): String {
     val minutes = Minutes.minutesBetween(now, endTime).minutes
 
     return when {
-        days > 0 -> "$days days"
-        hours > 0 -> "$hours hours"
-        else -> "$minutes minutes"
+        days > 0 -> "$days day(s)"
+        hours > 0 -> "$hours hour(s)"
+        else -> "$minutes minute(s)"
     }
 }
 


### PR DESCRIPTION
# Updates for join leave refactor & migration
- Update GuildMember to remove the leavehistory data from each record.
- Add new collection and service to save join / leave data separately.
- Add migration to update existing data in the db.
- Various file reformatting and changes.
- Added new activePunishments command to view current punishments and time remaining.
- Removed `viewAlts` alias for `alts`