### PR TITLE
fix: add validation for rule id in infraction conversation

### DIFF
--- a/src/main/kotlin/me/ddivad/judgebot/Main.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/Main.kt
@@ -57,7 +57,7 @@ suspend fun main(args: Array<String>) {
             field {
                 name = "Build Info"
                 value = "```" +
-                        "Version:   2.1.1\n" +
+                        "Version:   2.1.2\n" +
                         "DiscordKt: ${versions.library}\n" +
                         "Kotlin:    $kotlinVersion" +
                         "```"

--- a/src/main/kotlin/me/ddivad/judgebot/conversations/InfractionConversation.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/conversations/InfractionConversation.kt
@@ -23,7 +23,6 @@ class InfractionConversation(private val databaseService: DatabaseService,
         val rules = databaseService.guilds.getRules(guild)
         val ruleId = if (rules.isNotEmpty()) {
             respond { createInfractionRuleEmbed(guild, rules) }
-//            val rule = promptEmbed(IntegerArg) { createInfractionRuleEmbed(guild, rules) }
             val rule = promptUntil(
                     IntegerArg,
                     prompt = "Enter choice:",

--- a/src/main/kotlin/me/ddivad/judgebot/conversations/InfractionConversation.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/conversations/InfractionConversation.kt
@@ -22,7 +22,14 @@ class InfractionConversation(private val databaseService: DatabaseService,
                 else guildConfiguration.infractionConfiguration.warnPoints
         val rules = databaseService.guilds.getRules(guild)
         val ruleId = if (rules.isNotEmpty()) {
-            val rule = promptEmbed(IntegerArg) { createInfractionRuleEmbed(guild, rules) }
+            respond { createInfractionRuleEmbed(guild, rules) }
+//            val rule = promptEmbed(IntegerArg) { createInfractionRuleEmbed(guild, rules) }
+            val rule = promptUntil(
+                    IntegerArg,
+                    prompt = "Enter choice:",
+                    isValid = { number -> rules.any { it.number == number } || number == 0 },
+                    error = "Rule not found. Please enter a valid rule ID or 0:"
+            )
             if (rule > 0) rule else null
         } else null
         val infraction = Infraction(this.user.id.value, infractionReason, type, points, ruleId)


### PR DESCRIPTION
# fix: add validation for rule id in infraction conversation

Add a validation step in the infraction conversation to only allow valid rule ids to be sent.