### PR TITLE
fix: only add 1 button row to the alt menu

### DIFF
--- a/src/main/kotlin/me/ddivad/judgebot/Main.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/Main.kt
@@ -59,7 +59,7 @@ suspend fun main(args: Array<String>) {
             field {
                 name = "Build Info"
                 value = "```" +
-                    "Version:   2.2.1\n" +
+                    "Version:   2.2.2\n" +
                     "DiscordKt: ${versions.library}\n" +
                     "Kotlin:    $kotlinVersion" +
                     "```"

--- a/src/main/kotlin/me/ddivad/judgebot/embeds/UserEmbeds.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/embeds/UserEmbeds.kt
@@ -366,14 +366,14 @@ suspend fun MenuBuilder.createLinkedAccountMenu(
         page {
             createCondensedHistoryEmbed(linkedUser, linkedUserRecord, guild, config)
         }
+    }
 
-        buttons {
-            button("Prev.", Emojis.arrowLeft) {
-                previousPage()
-            }
-            button("Next", Emojis.arrowRight) {
-                nextPage()
-            }
+    buttons {
+        button("Prev.", Emojis.arrowLeft) {
+            previousPage()
+        }
+        button("Next", Emojis.arrowRight) {
+            nextPage()
         }
     }
 }


### PR DESCRIPTION
# fix: only add 1 button row to the alt menu

Fix cases where when a user has 2 or more alts, more than 1 button row gets added for the previous / next buttons.