### PR TITLE
feat: add rule number to infractions in history

### DIFF
--- a/src/main/kotlin/me/ddivad/judgebot/commands/InfractionCommands.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/commands/InfractionCommands.kt
@@ -1,5 +1,6 @@
 package me.ddivad.judgebot.commands
 
+import dev.kord.common.entity.Permission
 import me.ddivad.judgebot.arguments.LowerUserArg
 import dev.kord.common.exception.RequestException
 import dev.kord.x.emoji.Emojis
@@ -11,6 +12,7 @@ import me.ddivad.judgebot.dataclasses.Infraction
 import me.ddivad.judgebot.dataclasses.InfractionType
 import me.ddivad.judgebot.extensions.testDmStatus
 import me.ddivad.judgebot.services.*
+import me.ddivad.judgebot.extensions.*
 import me.ddivad.judgebot.services.infractions.BadPfpService
 import me.ddivad.judgebot.services.infractions.BadnameService
 import me.ddivad.judgebot.services.infractions.InfractionService

--- a/src/main/kotlin/me/ddivad/judgebot/commands/RuleCommands.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/commands/RuleCommands.kt
@@ -9,12 +9,12 @@ import me.ddivad.judgebot.dataclasses.Configuration
 import me.ddivad.judgebot.embeds.createRuleEmbed
 import me.ddivad.judgebot.embeds.createRulesEmbed
 import me.ddivad.judgebot.embeds.createRulesEmbedDetailed
-import me.ddivad.judgebot.extensions.jumpLink
 import me.ddivad.judgebot.services.DatabaseService
 import me.ddivad.judgebot.services.PermissionLevel
 import me.ddivad.judgebot.services.requiredPermissionLevel
 import me.jakejmattson.discordkt.api.arguments.MessageArg
 import me.jakejmattson.discordkt.api.dsl.commands
+import me.jakejmattson.discordkt.api.extensions.jumpLink
 
 @Suppress("unused")
 fun ruleCommands(configuration: Configuration,
@@ -57,7 +57,7 @@ fun ruleCommands(configuration: Configuration,
             val messageToEdit = args.first
             if (messageToEdit != null) {
                 messageToEdit.edit { this.embed { createRulesEmbed(guild, databaseService.guilds.getRules(guild)) } }
-                respond("Existing embed updated: ${messageToEdit.jumpLink(guild.id.asString)}")
+                respond("Existing embed updated: ${messageToEdit.jumpLink()}")
             } else {
                 respond {
                     createRulesEmbed(guild, databaseService.guilds.getRules(guild))
@@ -73,7 +73,7 @@ fun ruleCommands(configuration: Configuration,
             val messageToEdit = args.first
             if (messageToEdit != null) {
                 messageToEdit.edit { this.embed { createRulesEmbedDetailed(guild, databaseService.guilds.getRules(guild)) } }
-                respond("Existing embed updated: ${messageToEdit.jumpLink(guild.id.asString)}")
+                respond("Existing embed updated: ${messageToEdit.jumpLink()}")
             } else {
                 respond {
                     createRulesEmbedDetailed(guild, databaseService.guilds.getRules(guild))

--- a/src/main/kotlin/me/ddivad/judgebot/embeds/UserEmbeds.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/embeds/UserEmbeds.kt
@@ -120,7 +120,7 @@ private suspend fun MenuBuilder.buildOverviewPage(
 
             addField(
                 "**__Most Recent Infraction__**",
-                "Type: **${lastInfraction.type} (${lastInfraction.points})**\n " +
+                "Type: **${lastInfraction.type} (${lastInfraction.points})** Rule: **${lastInfraction.ruleNumber ?: "None"}**\n " +
                         "Issued by **${guild.kord.getUser(Snowflake(lastInfraction.moderator))?.username}** " +
                         "on **${SimpleDateFormat("dd/MM/yyyy").format(Date(lastInfraction.dateTime))}**\n" +
                         "Punishment: **${lastInfraction.punishment?.punishment}** ${getDurationText(lastInfraction.punishment)}\n" +
@@ -163,6 +163,7 @@ private suspend fun MenuBuilder.buildInfractionPage(
                 "ID :: ${infraction.id} :: Staff :: __${moderator}__",
                 "Type: **${infraction.type} (${infraction.points})** :: " +
                         "Date: **${SimpleDateFormat("dd/MM/yyyy").format(Date(infraction.dateTime))}**\n " +
+                        "Rule: **${infraction.ruleNumber ?: "None"}**\n" +
                         "Punishment: **${infraction.punishment?.punishment}** ${getDurationText(infraction.punishment)}\n" +
                         infraction.reason
             )
@@ -175,6 +176,7 @@ private suspend fun MenuBuilder.buildInfractionPage(
                 "ID :: ${infraction.id} :: Staff :: __${moderator}__",
                 "Type: **${infraction.type} (${infraction.points})** :: " +
                         "Date: **${SimpleDateFormat("dd/MM/yyyy").format(Date(infraction.dateTime))}**\n " +
+                        "Rule: **${infraction.ruleNumber ?: "None"}**\n" +
                         "Punishment: **${infraction.punishment?.punishment}** ${getDurationText(infraction.punishment)}\n" +
                         infraction.reason
             )

--- a/src/main/kotlin/me/ddivad/judgebot/extensions/Kord.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/extensions/Kord.kt
@@ -1,10 +1,7 @@
 package me.ddivad.judgebot.extensions
 
-import dev.kord.core.entity.Message
 import dev.kord.core.entity.User
 
 suspend fun User.testDmStatus() {
     getDmChannel().createMessage("Infraction message incoming").delete()
 }
-
-fun Message.jumpLink(guildId:String) = "https://discord.com/channels/${guildId}/${channel.id.value}/${id.value}"

--- a/src/main/kotlin/me/ddivad/judgebot/listeners/MemberReactionListeners.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/listeners/MemberReactionListeners.kt
@@ -6,8 +6,8 @@ import dev.kord.core.event.message.ReactionAddEvent
 import dev.kord.x.emoji.Emojis
 import dev.kord.x.emoji.addReaction
 import me.ddivad.judgebot.dataclasses.Configuration
-import me.ddivad.judgebot.extensions.jumpLink
 import me.jakejmattson.discordkt.api.dsl.listeners
+import me.jakejmattson.discordkt.api.extensions.jumpLink
 import me.jakejmattson.discordkt.api.extensions.toSnowflake
 
 @Suppress("unused")
@@ -28,7 +28,7 @@ fun onMemberReactionAdd(configuration: Configuration) = listeners {
                                 "\n**User**: ${user.mention}" +
                                 "\n**Channel**: ${message.channel.mention}" +
                                 "\n**Author:** ${message.asMessage().author?.mention}" +
-                                "\n**Message:** ${message.asMessage().jumpLink(guild.id.asString)}"
+                                "\n**Message:** ${message.asMessage().jumpLink()}"
                     )
                     .addReaction(Emojis.question)
             }


### PR DESCRIPTION
# feat: add rule number to infractions in history

- Add rule number to history embed.
- Remove `jumplink` extension and use the DiscordKt implementation.