### PR TITLE
 feat: update permission overrides to include new thread send messages permission

### DIFF
--- a/src/main/kotlin/me/ddivad/judgebot/Main.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/Main.kt
@@ -36,11 +36,12 @@ suspend fun main() {
             entitySupplyStrategy = EntitySupplyStrategy.cacheWithRestFallback
             permissions(Permissions.NONE)
             intents = Intents(
+                Intent.Guilds,
+                Intent.GuildBans,
                 Intent.GuildMembers,
                 Intent.DirectMessages,
-                Intent.GuildBans,
-                Intent.Guilds,
-                Intent.GuildMessageReactions
+                Intent.GuildMessageReactions,
+                Intent.DirectMessagesReactions
             )
         }
 

--- a/src/main/kotlin/me/ddivad/judgebot/Main.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/Main.kt
@@ -70,7 +70,7 @@ suspend fun main() {
             field {
                 name = "Build Info"
                 value = "```" +
-                    "Version:   2.5.0\n" +
+                    "Version:   2.5.1\n" +
                     "DiscordKt: ${versions.library}\n" +
                     "Kord: ${versions.kord}\n" +
                     "Kotlin:    $kotlinVersion" +

--- a/src/main/kotlin/me/ddivad/judgebot/commands/MuteCommands.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/commands/MuteCommands.kt
@@ -11,6 +11,7 @@ import me.ddivad.judgebot.services.infractions.RoleState
 import me.ddivad.judgebot.util.timeToString
 import me.jakejmattson.discordkt.api.arguments.EveryArg
 import me.jakejmattson.discordkt.api.arguments.TimeArg
+import me.jakejmattson.discordkt.api.arguments.UserArg
 import me.jakejmattson.discordkt.api.commands.commands
 import kotlin.math.roundToLong
 

--- a/src/main/kotlin/me/ddivad/judgebot/listeners/NewChannelOverrideListener.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/listeners/NewChannelOverrideListener.kt
@@ -18,11 +18,11 @@ fun onChannelCreated(configuration: Configuration, loggingService: LoggingServic
         val guildConfiguration = configuration[guild.id.value] ?: return@on
         val mutedRole = guild.getRole(guildConfiguration.mutedRole.toSnowflake())
         val deniedPermissions = channel.getPermissionOverwritesForRole(mutedRole.id)?.denied ?: Permissions()
-        if (deniedPermissions.values.any { it in setOf(Permission.SendMessages, Permission.AddReactions, Permission.UsePublicThreads, Permission.UsePrivateThreads) }) {
+        if (deniedPermissions.values.any { it in setOf(Permission.SendMessages, Permission.AddReactions, Permission.CreatePublicThreads, Permission.CreatePrivateThreads, Permission.SendMessagesInThreads) }) {
             channel.addOverwrite(
                 PermissionOverwrite.forRole(
                     mutedRole.id,
-                    denied = deniedPermissions.plus(Permission.SendMessages).plus(Permission.AddReactions).plus(Permission.UsePublicThreads).plus(Permission.UsePrivateThreads)
+                    denied = deniedPermissions.plus(Permission.SendMessages).plus(Permission.AddReactions).plus(Permission.CreatePrivateThreads).plus(Permission.CreatePrivateThreads).plus(Permission.SendMessagesInThreads)
                 ),
                 "Judgebot Overwrite"
             )

--- a/src/main/kotlin/me/ddivad/judgebot/services/infractions/MuteService.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/services/infractions/MuteService.kt
@@ -163,14 +163,14 @@ class MuteService(val configuration: Configuration,
         val mutedRole = guild.getRole(configuration[guild.id.value]!!.mutedRole.toSnowflake())
         guild.withStrategy(EntitySupplyStrategy.cachingRest).channels.toList().forEach {
             val deniedPermissions = it.getPermissionOverwritesForRole(mutedRole.id)?.denied ?: Permissions()
-            if (deniedPermissions.values.any { permission -> permission in setOf(Permission.SendMessages, Permission.AddReactions, Permission.UsePublicThreads, Permission.UsePrivateThreads) }) {
+            if (deniedPermissions.values.any { permission -> permission in setOf(Permission.SendMessages, Permission.AddReactions, Permission.CreatePublicThreads, Permission.CreatePrivateThreads, Permission.SendMessagesInThreads) }) {
                 try {
 
                     it.addOverwrite(
                         PermissionOverwrite.forRole(
                             mutedRole.id,
                             denied = deniedPermissions.plus(Permission.SendMessages).plus(Permission.AddReactions)
-                                .plus(Permission.UsePublicThreads).plus(Permission.UsePrivateThreads)
+                                .plus(Permission.CreatePrivateThreads).plus(Permission.CreatePrivateThreads).plus(Permission.SendMessagesInThreads)
                         ),
                         "Judgebot Overwrite"
                     )


### PR DESCRIPTION
# feat: update permission overrides to include new thread send messages permission

- Updated DiscordKt snapshot version and added the `Send Messages in Threads` permission override for the muted role