### PR TITLE
fix: add check for delete message days to make sure it can't be > 7

### DIFF
--- a/src/main/kotlin/me/ddivad/judgebot/Main.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/Main.kt
@@ -70,7 +70,7 @@ suspend fun main() {
             field {
                 name = "Build Info"
                 value = "```" +
-                    "Version:   2.5.1\n" +
+                    "Version:   2.5.2\n" +
                     "DiscordKt: ${versions.library}\n" +
                     "Kord: ${versions.kord}\n" +
                     "Kotlin:    $kotlinVersion" +

--- a/src/main/kotlin/me/ddivad/judgebot/commands/UserCommands.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/commands/UserCommands.kt
@@ -79,6 +79,10 @@ fun createUserCommands(
         requiredPermission = Permissions.STAFF
         execute(LowerUserArg, IntegerArg("Delete message days").optional(0), EveryArg) {
             val (target, deleteDays, reason) = args
+            if (deleteDays > 7) {
+                respond("Delete days cannot be more than **7**. You tried with **${deleteDays}**")
+                return@execute
+            }
             val ban = Punishment(target.id.asString, InfractionType.Ban, reason, author.id.asString)
             banService.banUser(target, guild, ban, deleteDays).also {
                 loggingService.userBanned(guild, target, ban)


### PR DESCRIPTION
## fix: add check for delete message days to make sure it can't be > 7

- Add a check for delete message days to make sure it can be more than 7. Avoids an edge case where a number higher than 7 is the first part of the ban reason.