### PR TITLE
feat: add deleted message tracking

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -54,19 +54,20 @@
 | rules       | [Message] | List the rules of this guild. Pass a message ID to edit existing rules embed.                     |
 
 ## User
-| Commands      | Arguments                                 | Description                                                |
-| ------------- | ----------------------------------------- | ---------------------------------------------------------- |
-| alts          | User                                      | Use this to view a user's alt accounts.                    |
-| ban           | LowerUserArg, [Delete message days], Text | Ban a member from this guild.                              |
-| getBanReason  | User                                      | Get a ban reason for a banned user                         |
-| history, h, H | User                                      | Use this to view a user's record.                          |
-| link          | Main Account, Alt Account                 | Link a user's alt account with their main                  |
-| reset         | LowerUserArg                              | Reset a user's record, and any linked accounts             |
-| selfHistory   |                                           | View your infraction history (contents will be DM'd)       |
-| setBanReason  | User, Reason                              | Set a ban reason for a banned user                         |
-| unban         | User                                      | Unban a banned member from this guild.                     |
-| unlink        | Main Account, Alt Account                 | Link a user's alt account with their main                  |
-| whatpfp       | User                                      | Perform a reverse image search of a User's profile picture |
+| Commands        | Arguments                                 | Description                                                     |
+| --------------- | ----------------------------------------- | --------------------------------------------------------------- |
+| alts            | User                                      | Use this to view a user's alt accounts.                         |
+| ban             | LowerUserArg, [Delete message days], Text | Ban a member from this guild.                                   |
+| deletedMessages | LowerUserArg                              | View a users messages deleted using the delete message reaction |
+| getBanReason    | User                                      | Get a ban reason for a banned user                              |
+| history, h, H   | User                                      | Use this to view a user's record.                               |
+| link            | Main Account, Alt Account                 | Link a user's alt account with their main                       |
+| reset           | LowerUserArg                              | Reset a user's record, and any linked accounts                  |
+| selfHistory     |                                           | View your infraction history (contents will be DM'd)            |
+| setBanReason    | User, Reason                              | Set a ban reason for a banned user                              |
+| unban           | User                                      | Unban a banned member from this guild.                          |
+| unlink          | Main Account, Alt Account                 | Link a user's alt account with their main                       |
+| whatpfp         | User                                      | Perform a reverse image search of a User's profile picture      |
 
 ## Utility
 | Commands | Arguments | Description                              |

--- a/src/main/kotlin/me/ddivad/judgebot/arguments/LowerUserArg.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/arguments/LowerUserArg.kt
@@ -1,6 +1,7 @@
 package me.ddivad.judgebot.arguments
 
 import dev.kord.core.entity.User
+import me.ddivad.judgebot.dataclasses.Configuration
 import me.jakejmattson.discordkt.arguments.*
 import me.jakejmattson.discordkt.commands.CommandEvent
 import me.jakejmattson.discordkt.extensions.isSelf
@@ -15,6 +16,7 @@ open class LowerUserArg(override val name: String = "LowerUserArg") : Argument<U
 
     override suspend fun convert(arg: String, args: List<String>, event: CommandEvent<*>): ArgumentResult<User> {
         val guild = event.guild ?: return Error("No guild found")
+        val configuration = event.discord.getInjectionObjects(Configuration :: class)
 
         val user = arg.toSnowflakeOrNull()?.let { guild.kord.getUser(it) } ?: return Error("User Not Found")
         val member = guild.getMemberOrNull(user.id) ?: return Success(user)
@@ -23,7 +25,8 @@ open class LowerUserArg(override val name: String = "LowerUserArg") : Argument<U
         return when {
             event.discord.permissions.isHigherLevel(event.discord, member, author) || event.author.isSelf() ->
                 Error("You don't have the permission to use this command on the target user.")
-            event.author == member -> Error("You can't use this command on yourself!")
+            (event.author == member && member.id.toString() != configuration.ownerId) ->
+                Error("You can't use this command on yourself!")
             else -> Success(member.asUser())
         }
     }

--- a/src/main/kotlin/me/ddivad/judgebot/dataclasses/MessageDelete.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/dataclasses/MessageDelete.kt
@@ -1,0 +1,10 @@
+package me.ddivad.judgebot.dataclasses
+
+import java.util.Date
+
+data class MessageDelete(
+    val userId: String,
+    val guildId: String,
+    val messageLink: String?,
+    val dateTime: Long = Date().time,
+)

--- a/src/main/kotlin/me/ddivad/judgebot/services/DatabaseService.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/services/DatabaseService.kt
@@ -2,6 +2,7 @@ package me.ddivad.judgebot.services
 
 import me.ddivad.judgebot.services.database.GuildOperations
 import me.ddivad.judgebot.services.database.JoinLeaveOperations
+import me.ddivad.judgebot.services.database.MessageDeleteOperations
 import me.ddivad.judgebot.services.database.UserOperations
 import me.jakejmattson.discordkt.annotations.Service
 
@@ -9,5 +10,6 @@ import me.jakejmattson.discordkt.annotations.Service
 open class DatabaseService(
     val users: UserOperations,
     val guilds: GuildOperations,
-    val joinLeaves: JoinLeaveOperations
+    val joinLeaves: JoinLeaveOperations,
+    val messageDeletes: MessageDeleteOperations
 )

--- a/src/main/kotlin/me/ddivad/judgebot/services/database/MessageDeleteOperations.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/services/database/MessageDeleteOperations.kt
@@ -1,0 +1,26 @@
+package me.ddivad.judgebot.services.database
+
+import dev.kord.core.entity.Member
+import me.ddivad.judgebot.dataclasses.MessageDelete
+import me.jakejmattson.discordkt.annotations.Service
+import org.litote.kmongo.and
+import org.litote.kmongo.eq
+
+@Service
+class MessageDeleteOperations(connection: ConnectionService) {
+    private val messageDeleteCollection = connection.db.getCollection<MessageDelete>("MessageDelete")
+
+    suspend fun createMessageDeleteRecord(guildId: String, target: Member, messageLink: String?) {
+        val record = MessageDelete(target.id.toString(), guildId, messageLink)
+        messageDeleteCollection.insertOne(record)
+    }
+
+    suspend fun getMessageDeletesForMember(guildId: String, userId: String): List<MessageDelete> {
+        return messageDeleteCollection.find(
+            and(
+                MessageDelete::guildId eq guildId,
+                MessageDelete::userId eq userId,
+            )
+        ).toList()
+    }
+}


### PR DESCRIPTION
# feat: add deleted message tracking

Added:
- New collection to hold links to user's deleted messages that get logged when the delete message reaction is used.
- New command `deletedMessages` to display all of a user's deleted messages.
- Update LowerUserArg and LowerMemberArg to allow the bot owner to use commands on themselves.
- Improve logging for the deleted message reaction.