### PR TITLE
fix: update getHighestRolePosition to account for bots

### DIFF
--- a/src/main/kotlin/me/ddivad/judgebot/extensions/Kord.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/extensions/Kord.kt
@@ -9,7 +9,10 @@ suspend fun User.testDmStatus() {
     getDmChannel().createMessage("Infraction message incoming").delete()
 }
 
-suspend fun Member.getHighestRolePosition() = roles.toList().maxByOrNull { it.rawPosition }?.rawPosition ?: -1
+suspend fun Member.getHighestRolePosition(): Int {
+    if (isBot) return -1
+    return roles.toList().maxByOrNull { it.rawPosition }?.rawPosition ?: -1
+}
 
 fun Member.hasStaffRoles(guildConfiguration: GuildConfiguration): Boolean {
     val staffRoleIds =


### PR DESCRIPTION
# fix: update getHighestRolePosition to account for bots

Fix `getHighestRolePosition` to account for bot roles. The old version of this function failed for the ❓ reactions, as `messageAuthor.getHighestRolePosition` in the `StaffReactionListeners` check was returning the bot, which has higher role positions than all staff except admins.