### PR TITLE
Rename strike parameter to 'reason' to match warn naming

### DIFF
--- a/src/main/kotlin/me/ddivad/judgebot/commands/InfractionCommands.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/commands/InfractionCommands.kt
@@ -79,7 +79,7 @@ fun createInfractionCommands(
         execute(
             LowerMemberArg("Member", "Target Member"),
             autoCompletingRuleArg(databaseService),
-            EveryArg,
+            AnyArg("Reason", "Infraction reason to send to user"),
             autoCompletingWeightArg(config)
         ) {
             val (targetMember, ruleName, reason, weight) = args


### PR DESCRIPTION
I recently had to switch from a warn to a strike half-way through sending it and that changing just the command wasn't enough :')