### PR TITLE
Add delete message context & fix whatpfp url

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import java.util.*
 
 group = "me.ddivad"
-version = "2.0.0-RC1"
+version = "2.9.0"
 description = "A bot for managing discord infractions in an intelligent and user-friendly way."
 
 plugins {

--- a/commands.md
+++ b/commands.md
@@ -50,19 +50,20 @@
 | reset             | LowerUserArg, choice | Reset a user's notes, infractions or whole record           |
 
 ## Context
-| Commands           | Arguments | Description                                                                                     |
-|--------------------|-----------|-------------------------------------------------------------------------------------------------|
-| contextUserBadpfp  | User      | Apply a badpfp to a user (please use via the 'Apps' menu instead of as a command)               |
-| contextUserHistory | User      | View a condensed history for this user (please use via the 'Apps' menu instead of as a command) |
-| report             | Message   | Report a message to staff (please use via the 'Apps' menu instead of as a command)              |
+| Commands             | Arguments | Description                                                                                     |
+|----------------------|-----------|-------------------------------------------------------------------------------------------------|
+| contextMessageDelete | Message   | Delete a message and notify a user via DM                                                       |
+| contextUserBadpfp    | User      | Apply a badpfp to a user (please use via the 'Apps' menu instead of as a command)               |
+| contextUserHistory   | User      | View a condensed history for this user (please use via the 'Apps' menu instead of as a command) |
+| report               | Message   | Report a message to staff (please use via the 'Apps' menu instead of as a command)              |
 
 ## Infraction
-| Commands | Arguments                     | Description                                                                  |
-|----------|-------------------------------|------------------------------------------------------------------------------|
-| badname  | Member                        | Rename a guild member that has a bad name.                                   |
-| badpfp   | Option, Member                | Mutes a user and prompts them to change their pfp with a 30 minute ban timer |
-| strike   | Member, Rule, Text, [Weight]  | Strike a user.                                                               |
-| warn     | Member, Rule, Reason, [Force] | Warn a user.                                                                 |
+| Commands | Arguments                      | Description                                                                  |
+|----------|--------------------------------|------------------------------------------------------------------------------|
+| badname  | Member                         | Rename a guild member that has a bad name.                                   |
+| badpfp   | Option, Member                 | Mutes a user and prompts them to change their pfp with a 30 minute ban timer |
+| strike   | Member, Rule, Reason, [Weight] | Strike a user.                                                               |
+| warn     | Member, Rule, Reason, [Force]  | Warn a user.                                                                 |
 
 ## Mute
 | Commands | Arguments            | Description                       |

--- a/src/main/kotlin/me/ddivad/judgebot/commands/ContextCommands.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/commands/ContextCommands.kt
@@ -89,7 +89,8 @@ fun contextCommands(
         message(
             "Delete Message",
             "contextMessageDelete",
-            "Delete a message and notify a user via DM"
+            "Delete a message and notify a user via DM",
+            Permissions.STAFF
         ) {
             val targetMember = arg.getAuthorAsMember() ?: return@message
             val interactionResponse = interaction!!.deferEphemeralResponse()

--- a/src/main/kotlin/me/ddivad/judgebot/commands/ContextCommands.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/commands/ContextCommands.kt
@@ -12,11 +12,12 @@ import me.ddivad.judgebot.embeds.createSelfHistoryEmbed
 import me.ddivad.judgebot.extensions.hasStaffRoles
 import me.ddivad.judgebot.services.DatabaseService
 import me.ddivad.judgebot.services.infractions.BadPfpService
+import me.ddivad.judgebot.services.infractions.InfractionService
 import me.ddivad.judgebot.util.createFlagMessage
 import me.jakejmattson.discordkt.commands.commands
 
 @Suppress("Unused")
-fun contextCommands(configuration: Configuration, databaseService: DatabaseService, badPfpService: BadPfpService) =
+fun contextCommands(configuration: Configuration, databaseService: DatabaseService, badPfpService: BadPfpService, infractionService: InfractionService) =
     commands("Context") {
         message(
             "Report Message",
@@ -75,5 +76,14 @@ fun contextCommands(configuration: Configuration, databaseService: DatabaseServi
             interactionResponse.respond {
                 content = "${targetMember.mention} has been muted and a badpfp has been triggered."
             }
+        }
+
+        message(
+            "Delete Message",
+            "contextMessageDelete",
+            "Delete a message and notify a user via DM"
+        ) {
+            val targetMember = arg.getAuthorAsMember() ?: return@message
+            infractionService.deleteMessage(guild, targetMember, arg, author.asMember(guild.id))
         }
     }

--- a/src/main/kotlin/me/ddivad/judgebot/commands/ContextCommands.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/commands/ContextCommands.kt
@@ -1,5 +1,6 @@
 package me.ddivad.judgebot.commands
 
+import dev.kord.common.exception.RequestException
 import dev.kord.core.behavior.getChannelOf
 import dev.kord.core.behavior.interaction.response.respond
 import dev.kord.core.entity.channel.TextChannel
@@ -8,6 +9,7 @@ import dev.kord.x.emoji.addReaction
 import me.ddivad.judgebot.dataclasses.Configuration
 import me.ddivad.judgebot.dataclasses.Permissions
 import me.ddivad.judgebot.embeds.createCondensedHistoryEmbed
+import me.ddivad.judgebot.embeds.createMessageDeleteEmbed
 import me.ddivad.judgebot.embeds.createSelfHistoryEmbed
 import me.ddivad.judgebot.extensions.hasStaffRoles
 import me.ddivad.judgebot.services.DatabaseService
@@ -15,9 +17,15 @@ import me.ddivad.judgebot.services.infractions.BadPfpService
 import me.ddivad.judgebot.services.infractions.InfractionService
 import me.ddivad.judgebot.util.createFlagMessage
 import me.jakejmattson.discordkt.commands.commands
+import me.jakejmattson.discordkt.extensions.sendPrivateMessage
 
 @Suppress("Unused")
-fun contextCommands(configuration: Configuration, databaseService: DatabaseService, badPfpService: BadPfpService, infractionService: InfractionService) =
+fun contextCommands(
+    configuration: Configuration,
+    databaseService: DatabaseService,
+    badPfpService: BadPfpService,
+    infractionService: InfractionService
+) =
     commands("Context") {
         message(
             "Report Message",
@@ -84,6 +92,17 @@ fun contextCommands(configuration: Configuration, databaseService: DatabaseServi
             "Delete a message and notify a user via DM"
         ) {
             val targetMember = arg.getAuthorAsMember() ?: return@message
+            val interactionResponse = interaction!!.deferEphemeralResponse()
             infractionService.deleteMessage(guild, targetMember, arg, author.asMember(guild.id))
+            try {
+                targetMember.sendPrivateMessage {
+                    createMessageDeleteEmbed(guild, arg)
+                }
+                interactionResponse.respond { content = "Message deleted" }
+            } catch (ex: RequestException) {
+                interactionResponse.respond {
+                    content = "User ${targetMember.mention} has DM's disabled. Message deleted without notification."
+                }
+            }
         }
     }

--- a/src/main/kotlin/me/ddivad/judgebot/commands/InfractionCommands.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/commands/InfractionCommands.kt
@@ -18,7 +18,6 @@ import me.ddivad.judgebot.services.infractions.InfractionService
 import me.jakejmattson.discordkt.arguments.AnyArg
 import me.jakejmattson.discordkt.arguments.BooleanArg
 import me.jakejmattson.discordkt.arguments.ChoiceArg
-import me.jakejmattson.discordkt.arguments.EveryArg
 import me.jakejmattson.discordkt.commands.commands
 import me.jakejmattson.discordkt.extensions.createMenu
 

--- a/src/main/kotlin/me/ddivad/judgebot/commands/UserCommands.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/commands/UserCommands.kt
@@ -120,7 +120,7 @@ fun createUserCommands(
 
     user("PFP Lookup", "whatpfp","Perform a reverse image search of a User's profile picture", Permissions.EVERYONE) {
         val user = args.first
-        val reverseSearchUrl = "<https://www.google.com/searchbyimage?&image_url=${user.pfpUrl}>"
+        val reverseSearchUrl = "<https://lens.google.com/uploadbyurl?url=${user.pfpUrl}>"
 
         if (interaction?.invokedCommandType == ApplicationCommandType.User) {
             respond {

--- a/src/main/kotlin/me/ddivad/judgebot/listeners/StaffReactionListeners.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/listeners/StaffReactionListeners.kt
@@ -1,27 +1,22 @@
 package me.ddivad.judgebot.listeners
 
-import dev.kord.common.exception.RequestException
 import dev.kord.core.event.message.ReactionAddEvent
 import dev.kord.x.emoji.Emojis
 import dev.kord.x.emoji.addReaction
 import me.ddivad.judgebot.dataclasses.Configuration
-import me.ddivad.judgebot.embeds.createMessageDeleteEmbed
 import me.ddivad.judgebot.extensions.getHighestRolePosition
 import me.ddivad.judgebot.extensions.hasStaffRoles
-import me.ddivad.judgebot.services.DatabaseService
 import me.ddivad.judgebot.services.LoggingService
 import me.ddivad.judgebot.services.infractions.InfractionService
 import me.ddivad.judgebot.services.infractions.MuteService
 import me.ddivad.judgebot.services.infractions.MuteState
 import me.jakejmattson.discordkt.dsl.listeners
 import me.jakejmattson.discordkt.extensions.isSelf
-import me.jakejmattson.discordkt.extensions.jumpLink
 import me.jakejmattson.discordkt.extensions.sendPrivateMessage
 
 @Suppress("unused")
 fun onStaffReactionAdd(
     muteService: MuteService,
-    databaseService: DatabaseService,
     infractionService: InfractionService,
     loggingService: LoggingService,
     configuration: Configuration

--- a/src/main/kotlin/me/ddivad/judgebot/listeners/StaffReactionListeners.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/listeners/StaffReactionListeners.kt
@@ -1,9 +1,11 @@
 package me.ddivad.judgebot.listeners
 
+import dev.kord.common.exception.RequestException
 import dev.kord.core.event.message.ReactionAddEvent
 import dev.kord.x.emoji.Emojis
 import dev.kord.x.emoji.addReaction
 import me.ddivad.judgebot.dataclasses.Configuration
+import me.ddivad.judgebot.embeds.createMessageDeleteEmbed
 import me.ddivad.judgebot.extensions.getHighestRolePosition
 import me.ddivad.judgebot.extensions.hasStaffRoles
 import me.ddivad.judgebot.services.LoggingService
@@ -43,6 +45,16 @@ fun onStaffReactionAdd(
                 }
                 guildConfiguration.reactions.deleteMessageReaction -> {
                     infractionService.deleteMessage(guild, messageAuthor, msg, reactionUser)
+                    try {
+                        messageAuthor.sendPrivateMessage {
+                            createMessageDeleteEmbed(guild, msg)
+                        }
+                    } catch (ex: RequestException) {
+                        reactionUser.sendPrivateMessage(
+                            "User ${messageAuthor.mention} has DM's disabled." +
+                                    " Message deleted without notification."
+                        )
+                    }
                 }
                 Emojis.question.unicode -> {
                     if (this.user.isSelf() || msg.author != this.message.kord.getSelf()) return@on

--- a/src/main/kotlin/me/ddivad/judgebot/listeners/StaffReactionListeners.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/listeners/StaffReactionListeners.kt
@@ -10,6 +10,7 @@ import me.ddivad.judgebot.extensions.getHighestRolePosition
 import me.ddivad.judgebot.extensions.hasStaffRoles
 import me.ddivad.judgebot.services.DatabaseService
 import me.ddivad.judgebot.services.LoggingService
+import me.ddivad.judgebot.services.infractions.InfractionService
 import me.ddivad.judgebot.services.infractions.MuteService
 import me.ddivad.judgebot.services.infractions.MuteState
 import me.jakejmattson.discordkt.dsl.listeners
@@ -21,6 +22,7 @@ import me.jakejmattson.discordkt.extensions.sendPrivateMessage
 fun onStaffReactionAdd(
     muteService: MuteService,
     databaseService: DatabaseService,
+    infractionService: InfractionService,
     loggingService: LoggingService,
     configuration: Configuration
 ) = listeners {
@@ -45,29 +47,7 @@ fun onStaffReactionAdd(
                     reactionUser.sendPrivateMessage("${messageAuthor.mention} gagged.")
                 }
                 guildConfiguration.reactions.deleteMessageReaction -> {
-                    message.delete()
-                    databaseService.users.addMessageDelete(
-                        guild,
-                        databaseService.users.getOrCreateUser(messageAuthor, guild.asGuild()),
-                        true
-                    )
-                    try {
-                        messageAuthor.sendPrivateMessage {
-                            createMessageDeleteEmbed(guild, msg)
-                        }
-                    } catch (ex: RequestException) {
-                        reactionUser.sendPrivateMessage(
-                            "User ${messageAuthor.mention} has DM's disabled." +
-                                    " Message deleted without notification."
-                        )
-                    }
-                    val deleteLogMessage =
-                        loggingService.deleteReactionUsed(guild, reactionUser, messageAuthor, this.emoji, msg)
-                    databaseService.messageDeletes.createMessageDeleteRecord(
-                        guildId.toString(),
-                        messageAuthor,
-                        deleteLogMessage.first()?.jumpLink()
-                    )
+                    infractionService.deleteMessage(guild, messageAuthor, msg, reactionUser)
                 }
                 Emojis.question.unicode -> {
                     if (this.user.isSelf() || msg.author != this.message.kord.getSelf()) return@on

--- a/src/main/kotlin/me/ddivad/judgebot/services/LoggingService.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/services/LoggingService.kt
@@ -14,8 +14,6 @@ import me.jakejmattson.discordkt.extensions.descriptor
 import me.jakejmattson.discordkt.extensions.idDescriptor
 import me.jakejmattson.discordkt.extensions.pfpUrl
 import mu.KotlinLogging
-import java.text.SimpleDateFormat
-import java.util.*
 
 @Service
 class LoggingService(private val configuration: Configuration) {

--- a/src/main/kotlin/me/ddivad/judgebot/services/infractions/InfractionService.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/services/infractions/InfractionService.kt
@@ -24,7 +24,6 @@ class InfractionService(
     private val banService: BanService,
     private val muteService: MuteService
 ) {
-
     suspend fun infract(target: Member, guild: Guild, userRecord: GuildMember, infraction: Infraction): Infraction {
         var rule: Rule? = null
         if (infraction.ruleNumber != null) {

--- a/src/main/kotlin/me/ddivad/judgebot/services/infractions/InfractionService.kt
+++ b/src/main/kotlin/me/ddivad/judgebot/services/infractions/InfractionService.kt
@@ -67,16 +67,6 @@ class InfractionService(
             databaseService.users.getOrCreateUser(target, guild),
             true
         )
-        try {
-            target.sendPrivateMessage {
-                createMessageDeleteEmbed(guild, message)
-            }
-        } catch (ex: RequestException) {
-            moderator.sendPrivateMessage(
-                "User ${target.mention} has DM's disabled." +
-                        " Message deleted without notification."
-            )
-        }
         val deleteLogMessage =
             loggingService.deleteReactionUsed(guild, moderator, target, Emojis.wastebasket.toReaction(), message)
         databaseService.messageDeletes.createMessageDeleteRecord(

--- a/src/main/resources/bot.properties
+++ b/src/main/resources/bot.properties
@@ -1,4 +1,4 @@
-#Sat Feb 04 21:41:48 GMT 2023
+#Sat Feb 04 21:56:57 GMT 2023
 description=A bot for managing discord infractions in an intelligent and user-friendly way.
 name=Judgebot
 url=https\://github.com/the-programmers-hangout/JudgeBot/

--- a/src/main/resources/bot.properties
+++ b/src/main/resources/bot.properties
@@ -1,4 +1,4 @@
-#Sat Feb 04 19:00:40 GMT 2023
+#Sat Feb 04 21:41:48 GMT 2023
 description=A bot for managing discord infractions in an intelligent and user-friendly way.
 name=Judgebot
 url=https\://github.com/the-programmers-hangout/JudgeBot/

--- a/src/main/resources/bot.properties
+++ b/src/main/resources/bot.properties
@@ -1,4 +1,4 @@
-#Sat Feb 04 22:10:19 GMT 2023
+#Sat Feb 04 22:24:41 GMT 2023
 description=A bot for managing discord infractions in an intelligent and user-friendly way.
 name=Judgebot
 url=https\://github.com/the-programmers-hangout/JudgeBot/

--- a/src/main/resources/bot.properties
+++ b/src/main/resources/bot.properties
@@ -1,5 +1,5 @@
-#Sun Sep 11 13:05:31 BST 2022
-name=Judgebot
+#Sat Feb 04 19:00:40 GMT 2023
 description=A bot for managing discord infractions in an intelligent and user-friendly way.
-version=2.0.0-RC1
+name=Judgebot
 url=https\://github.com/the-programmers-hangout/JudgeBot/
+version=2.0.0-RC1

--- a/src/main/resources/bot.properties
+++ b/src/main/resources/bot.properties
@@ -1,5 +1,5 @@
-#Sat Feb 04 21:56:57 GMT 2023
+#Sat Feb 04 22:10:19 GMT 2023
 description=A bot for managing discord infractions in an intelligent and user-friendly way.
 name=Judgebot
 url=https\://github.com/the-programmers-hangout/JudgeBot/
-version=2.0.0-RC1
+version=2.9.0


### PR DESCRIPTION
# Add delete message context & fix whatpfp url

- Add context command for deleting a message. This will work in cases where a user has a staff member blocked meaning the reaction can't be used.
- FIx reverse image search by updating to the Google Lens URL.